### PR TITLE
patch for 'includeexpr'

### DIFF
--- a/ftplugin/perl.vim
+++ b/ftplugin/perl.vim
@@ -30,7 +30,7 @@ endif
 " Provided by Ned Konz <ned at bike-nomad dot com>
 "---------------------------------------------
 setlocal include=\\<\\(use\\\|require\\)\\>
-setlocal includeexpr=substitute(substitute(substitute(v:fname,'::','/','g'),'[-/]\\?$','.pm',''),'^q[qw]\\?/','','')
+setlocal includeexpr=substitute(substitute(v:fname,'^.\\{-}\\([A-Za-z0-9_:]\\+\\)[^A-Za-z0-9_:]*$','\\1.pm',''),'::','/','g')
 setlocal define=[^A-Za-z_]
 
 " The following line changes a global variable but is necessary to make


### PR DESCRIPTION
Hi,

hitting `gf` on the module name `Foo::Bar` in the code below
    Foo::Bar->baz;
    use base qw/Foo::Bar/;
causes unintended error such as `E447: Can't find file "Foo/Bar-.pm" in path` or `E447: Can't find file "qw/Foo/Bar/.pm" in path`. This commit would fix that behavior.

Thanks,
motemen
