### PR TITLE
not all .html files should be ignored.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 *~
 .*.swp
 vim-perl.tar.gz
-t_source/*/*.html
+t_source/*/*_fail.html


### PR DESCRIPTION
trivial fix to .gitignore:  only the ${name}_fail.html are autogenerated, the others are required for the tests.
