### PR TITLE
avoid overwriting 'path'; restore it after use

### DIFF
--- a/ftplugin/perl.vim
+++ b/ftplugin/perl.vim
@@ -60,11 +60,22 @@ if !exists("perlpath")
     endif
 endif
 
-let &l:path=perlpath
+" Append perlpath to the existing path value, if it is set.  Since we don't
+" use += to do it because of the commas in perlpath, we have to handle the
+" global / local settings, too.
+if &l:path == ""
+    if &g:path == ""
+        let &l:path=perlpath
+    else
+        let &l:path=&g:path.",".perlpath
+    endif
+else
+    let &l:path=&l:path.",".perlpath
+endif
 "---------------------------------------------
 
 " Undo the stuff we changed.
-let b:undo_ftplugin = "setlocal fo< com< cms< inc< inex< def< isf< kp<" .
+let b:undo_ftplugin = "setlocal fo< com< cms< inc< inex< def< isf< kp< path<" .
 	    \	      " | unlet! b:browsefilter"
 
 " Restore the saved compatibility options.


### PR DESCRIPTION
change by Dan Sharp
