### PR TITLE
added newer efm_perl.pl for syntax checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,14 @@ PREFIX?=$(HOME)/.vim
 FTPLUGIN=$(PREFIX)/ftplugin
 INDENT=$(PREFIX)/indent
 SYNTAX=$(PREFIX)/syntax
+TOOLS=$(PREFIX)/tools
 
 default:
 	@echo There is no default target.
 	@echo Some handle targets: test, install
 
 dirs:
-	mkdir -p $(FTPLUGIN) $(INDENT) $(SYNTAX)
+	mkdir -p $(FTPLUGIN) $(INDENT) $(SYNTAX) $(TOOLS)
 
 install: dirs
 	cp ftplugin/perl.vim  $(FTPLUGIN)
@@ -23,6 +24,7 @@ install: dirs
 	cp syntax/tt2.vim     $(SYNTAX)
 	cp syntax/tt2html.vim $(SYNTAX)
 	cp syntax/xs.vim      $(SYNTAX)
+	cp tools/efm_perl.pl  $(TOOLS)
 
 symlinks: dirs
 	ln -sf $(PWD)/ftplugin/perl.vim  $(FTPLUGIN)
@@ -36,8 +38,9 @@ symlinks: dirs
 	ln -sf $(PWD)/syntax/tt2.vim     $(SYNTAX)
 	ln -sf $(PWD)/syntax/tt2html.vim $(SYNTAX)
 	ln -sf $(PWD)/syntax/xs.vim      $(SYNTAX)
+	ln -sf $(PWD)/tools/efm_perl.pl  $(TOOLS)
 
-tarball: 
+tarball:
 	tar czvf vim-perl.tar.gz \
 		ftplugin/perl.vim \
 		ftplugin/perl6.vim \
@@ -50,6 +53,8 @@ tarball:
 		syntax/perl6.vim \
 		syntax/pod.vim \
 		syntax/xs.vim \
+		\
+		tools/efm_perl.pl \
 
 test:
 	prove -rv t

--- a/tools/efm_perl.pl
+++ b/tools/efm_perl.pl
@@ -1,0 +1,68 @@
+#!/usr/bin/perl
+
+# This is shamelessly ripped from $VIMRUNTIME/tools/efm_perl.pl (which was last
+# updated in 2001 according to the version history--but I'm willing to accept
+# that someone has probably made changes to it since then.) Check that file for
+# details and historical information.
+
+use strict;
+use warnings;
+
+use Cwd;
+use File::Basename;
+
+die "Too many arguments!\n" if @ARGV > 1;
+
+my $file = shift or die "No filename to check!\n";
+my $dir  = dirname( $file ) . '/lib';
+my $cwd  = cwd() . '/lib';
+
+my $error = qr{(.*)\sat\s(.*)\sline\s(\d+)(\.|,\snear\s\".*\"?)};
+
+# Error messages to be skipped.
+my @skip = (
+
+  '"DB::single" used only once: possible typo',
+  'BEGIN failed--compilation aborted',
+
+);
+
+my $skip = join '|', @skip;
+
+# Thanks to
+#
+# http://blogs.perl.org/users/ovid/2011/01/warningsunused-versus-ppi.html for
+# the 'warnings::unused' trick.
+#
+# https://github.com/Ovid/DB--Color.git for the 'circular::require' trick
+
+# Note: Most of the following modules need to be installed, most are not
+# included in core.
+
+my @checks;
+
+push @checks, '-M-circular::require' if `perldoc -l circular::require 2> /dev/null`;
+push @checks, '-M-indirect'          if `perldoc -l indirect 2> /dev/null`;
+push @checks, '-Mwarnings::method'   if `perldoc -l warnings::method 2> /dev/null`;
+push @checks, '-Mwarnings::unused'   if `perldoc -l warnings::unused 2> /dev/null`;
+
+# uninit is not included in 5.10 and later
+push @checks, '-Muninit'             if ( $] < 5.010 ) && `perldoc -l uninit 2> /dev/null`;
+
+my $checks = join ' ', @checks;
+
+my ( $message, $extracted_file, $lineno, $rest );
+
+for my $line ( `perl -I $dir -I $cwd @checks -c $file 2>&1` ) {
+
+  chomp $line;
+  next if $line =~ /$skip/;
+  $line =~ s/([()])/\\$1/g;
+
+  if ( ( $message, $extracted_file, $lineno, $rest ) = $line =~ /^$error$/ ) {
+
+    $message .= $rest if ($rest =~ s/^,//);
+    print "$file:$lineno:$message\n";
+
+  }
+}


### PR DESCRIPTION
According to efm_perl.pl 's comments the file is more than 10 years old.  For the most part it works fine, but I added some checks (warnings::modules mainly) and a naïve attempt to include a working lib directory so spurious "Can't find module" warnings won't show up.

Of course, anything that will help improve this would be greatly appreciated.

I use this with syntastic to alert me when I've done something stupid.
