### PR TITLE
fold subs passed as last arg to function with '=>'

### DIFF
--- a/syntax/perl.vim
+++ b/syntax/perl.vim
@@ -400,7 +400,7 @@ if exists("perl_fold")
     syn region perlPackageFold start="^package \S\+;\s*\%(#.*\)\=$" end="^1;\=\s*\%(#.*\)\=$" end="\n\+package"me=s-1 transparent fold keepend
   endif
   if !exists("perl_nofold_subs")
-    syn region perlSubFold     start="^\z(\s*\)\<sub\>.*[^};]$" end="^\z1}\s*\%(#.*\)\=$" transparent fold keepend
+    syn region perlSubFold     start="^\z(\s*\)\(\w\+.*=>\s\+\)\?\<sub\>.*[^};]$" end="^\z1};\?\s*\%(#.*\)\=$" transparent fold keepend
     syn region perlSubFold start="^\z(\s*\)\<\%(BEGIN\|END\|CHECK\|INIT\|UNITCHECK\)\>.*[^};]$" end="^\z1}\s*$" transparent fold keepend
   endif
 


### PR DESCRIPTION
Some frameworks (e.g. Dancer, Test::More) use a style like this to pass
a code block to a subroutine:

```
subname 'description' => sub {
    # some implementation
};
```

This change makes it so that the above will fold.

---

All I added was the the possibility of something with a '=>' before the sub keyword `\(\w\+.*=>\s\+\)\?` and conditionally allowing there to be a semicolon at the end of the block `;\?`.
