### PR TITLE
Fix perlElseIfError when used in other syntax type

### DIFF
--- a/syntax/perl.vim
+++ b/syntax/perl.vim
@@ -64,7 +64,7 @@ syn region  perlGenericBlock	matchgroup=perlGenericBlock start="{" end="}" conta
 " All keywords
 "
 syn match perlConditional		"\<\%(if\|elsif\|unless\|given\|when\|default\)\>"
-syn match perlConditional		"\<else\>" nextgroup=perlElseIfError skipwhite skipnl skipempty
+syn match perlConditional		"\<else\%(\%(\_s\*if\>\)\|\>\)" contains=perlElseIfError skipwhite skipnl skipempty
 syn match perlRepeat			"\<\%(while\|for\%(each\)\=\|do\|until\|continue\)\>"
 syn match perlOperator			"\<\%(defined\|undef\|eq\|ne\|[gl][et]\|cmp\|not\|and\|or\|xor\|not\|bless\|ref\|do\)\>"
 syn match perlControl			"\<\%(BEGIN\|CHECK\|INIT\|END\|UNITCHECK\)\>"
@@ -188,8 +188,8 @@ syn match  perlSpecialMatch	"(\*\%(\%(PRUNE\|SKIP\|THEN\)\%(:[^)]*\)\=\|\%(MARK\
 " Highlight lines with only whitespace (only in blank delimited here documents) as errors
 syn match  perlNotEmptyLine	"^\s\+$" contained
 " Highlight "} else if (...) {", it should be "} else { if (...) { " or "} elsif (...) {"
-syn match perlElseIfError	"\s\+if" contained
-syn keyword perlElseIfError	elseif
+syn match perlElseIfError	"else\_s*if" containedin=perlConditional
+syn keyword perlElseIfError	elseif containedin=perlConditional
 
 " Variable interpolation
 "


### PR DESCRIPTION
When used in the Mason syntax type, the way the perlElseIfError group
was handled caused any line beginning with 'if' to be highlighted as an
error.  This is due to the way Vim includes other syntax files.
perlElseIfError was marked as 'contained', but wasn't limited to a
specific group.  When perl.vim gets included, perlElseIfError is then
allowed to exist at what was formerly the top level.

Instead, make the errant '\s*if' of 'elseif' and 'else if' a part of the
perlConditional group, so that perlElseIfError can be confined to
containedin=perlConditional.

In Perl files, everything that should be marked as a perlElseIfError is
handled properly.  In Mason files, this prevents the erroneous
perlElseIfError highlighting for 'if', but only marks 'elseif' as an
error (the :syn-keyword perlElseIfError works; the :syn-match doesn't).
