### PR TITLE
highlight TODO: in addition to TODO

### DIFF
--- a/syntax/perl.vim
+++ b/syntax/perl.vim
@@ -94,7 +94,7 @@ syn match perlStatementTime		"\<\%(gmtime\|localtime\|time\)\>"
 
 syn match perlStatementMisc		"\<\%(warn\|formline\|reset\|scalar\|prototype\|lock\|tied\=\|untie\)\>"
 
-syn keyword perlTodo			TODO TBD FIXME XXX NOTE contained
+syn keyword perlTodo			TODO TODO: TBD TBD: FIXME FIXME: XXX XXX: NOTE NOTE: contained
 
 syn region perlStatementIndirObjWrap   matchgroup=perlStatementIndirObj start="\<\%(map\|grep\|sort\|printf\=\|say\|system\|exec\)\>\s*{" end="}" contains=@perlTop,perlGenericBlock
 

--- a/t_source/perl/advanced.t
+++ b/t_source/perl/advanced.t
@@ -92,6 +92,9 @@ BEGIN {
         }
 }
 
+# todo notes
+# TODO line without colon
+# TODO: line with colon
 
 # Fold the DATA segment
 # XXX We should add some POD to show that that is highlighted correctly as well

--- a/t_source/perl/advanced.t.html
+++ b/t_source/perl/advanced.t.html
@@ -100,6 +100,9 @@
         }
 }
 
+<span class="synComment"># todo notes</span>
+<span class="synComment"># </span><span class="synTodo">TODO</span><span class="synComment"> line without colon</span>
+<span class="synComment"># </span><span class="synTodo">TODO</span><span class="synComment">: line with colon</span>
 
 <span class="synComment"># Fold the DATA segment</span>
 <span class="synComment"># </span><span class="synTodo">XXX</span><span class="synComment"> We should add some POD to show that that is highlighted correctly as well</span>


### PR DESCRIPTION
`perl-support.vim` plugin adds ':' to `iskeyword` option.
At least, its older releases added it (can't find it in the latest
version). I like it because it allows me to move around using */# commands
quickly.
But if this option is configured this way, `syntax/perl.vim` doesn't
highlight `TODO:` in comments, because `TODO:` is considered a complete
keyword.

Maybe I should've replaced `syn keyword perlTodo` with `syn match`, but
it's not too much of copy-pasting (see the patch), and that's what
`syntax/help.vim` does for `NOTE:` lines in vim help files:

```
vim71/syntax/help.vim:syn keyword helpNote      note Note NOTE note: Note: NOTE: Notes Notes:
```
