### PR TITLE
efm_perl needs to use taint switch if used on the shebang line

### DIFF
--- a/tools/efm_perl.pl
+++ b/tools/efm_perl.pl
@@ -49,6 +49,11 @@ push @checks, '-Mwarnings::unused'   if `perldoc -l warnings::unused 2> /dev/nul
 # uninit is not included in 5.10 and later
 push @checks, '-Muninit'             if ( $] < 5.010 ) && `perldoc -l uninit 2> /dev/null`;
 
+# need to turn on taint if it's on the shebang line.
+# naive check for [tT] switch ... will both t and T ever be used at the same time?
+my ( $taint ) = `head -n 1 $file` =~ /\s.*-.*?(t)/i;
+push @checks, "-$taint" if $taint ne '';
+
 my $checks = join ' ', @checks;
 
 my ( $message, $extracted_file, $lineno, $rest );


### PR DESCRIPTION
Syntastic issue [#422](https://github.com/scrooloose/syntastic/issues/422) brought up a good point about checking taint correctly.

This is a naive solution which seems to work as far as I've tested it.  Pointers to anything I missed or didn't take into account would be appreciated.

It does **not** handle the case of having multiple taint switches (e.g., -t -T or -tT) ... is this something that needs to be accounted for?
