### PR TITLE
check for definedness of $taint variable

### DIFF
--- a/tools/efm_perl.pl
+++ b/tools/efm_perl.pl
@@ -52,9 +52,7 @@ push @checks, '-Muninit'             if ( $] < 5.010 ) && `perldoc -l uninit 2> 
 # need to turn on taint if it's on the shebang line.
 # naive check for [tT] switch ... will both t and T ever be used at the same time?
 my ( $taint ) = `head -n 1 $file` =~ /\s.*-.*?(t)/i;
-push @checks, "-$taint" if $taint ne '';
-
-my $checks = join ' ', @checks;
+push @checks, "-$taint" if defined $taint;
 
 my ( $message, $extracted_file, $lineno, $rest );
 


### PR DESCRIPTION
If -[tT] is not used on the shebang line I'm getting unitialized warnings.  Check to see if $taint is defined to get rid of these warnings.
