### PR TITLE
Add a syntax file for highlighting Javascript tt files

### DIFF
--- a/syntax/tt2js.vim
+++ b/syntax/tt2js.vim
@@ -3,7 +3,7 @@
 " Author:        Yates, Peter <pd.yates@gmail.com>
 " Homepage:      http://github.com/vim-perl/vim-perl
 " Bugs/requests: http://github.com/vim-perl/vim-perl/issues
-" Last Change:   2010-07-21
+" Last Change:   2013-04-10
 
 if exists("b:current_syntax")
     finish


### PR DESCRIPTION
This provides syntax highlighting for javascript tt files in the same way tt2html works, it can be enabled like this:

```
au BufRead *.js.tt   set ft=tt2js
```
