### PR TITLE
Don't set 'iskeyword' globally

### DIFF
--- a/ftplugin/perl.vim
+++ b/ftplugin/perl.vim
@@ -33,14 +33,14 @@ endif
 setlocal include=\\<\\(use\\\|require\\)\\>
 setlocal includeexpr=substitute(substitute(substitute(v:fname,'::','/','g'),'->\*','',''),'$','.pm','')
 setlocal define=[^A-Za-z_]
+setlocal iskeyword+=:
 
 " The following line changes a global variable but is necessary to make
-" gf and similar commands work.  The change to iskeyword was incorrect.
-" Thanks to Andrew Pimlott for pointing out the problem. If this causes a
-" problem for you, add an after/ftplugin/perl.vim file that contains
+" gf and similar commands work. Thanks to Andrew Pimlott for pointing
+" out the problem. If this causes a problem for you, add an
+" after/ftplugin/perl.vim file that contains
 "       set isfname-=:
 set isfname+=:
-set iskeyword+=:
 
 " Set this once, globally.
 if !exists("perlpath")


### PR DESCRIPTION
That line was added in 11049a7 by Rob Hoelz, and I suspect he didn't
mean to make it global.
