### PR TITLE
perlcritic, perltidy comments added, fix bug in subs folding

### DIFF
--- a/syntax/perl.vim
+++ b/syntax/perl.vim
@@ -83,7 +83,7 @@ syn match perlControl			"\<\%(BEGIN\|CHECK\|INIT\|END\|UNITCHECK\)\>\_s*" nextgr
 
 syn match perlStatementStorage		"\<\%(my\|our\|local\|state\)\>"
 syn match perlStatementControl		"\<\%(return\|last\|next\|redo\|goto\|break\)\>"
-syn match perlStatementScalar		"\<\%(chom\=p\|chr\|crypt\|r\=index\|lc\%(first\)\=\|length\|ord\|pack\|sprintf\|substr\|uc\%(first\)\=\|fc\)\>"
+syn match perlStatementScalar		"\<\%(chom\=p\|chr\|crypt\|r\=index\|lc\%(first\)\=\|length\|ord\|pack\|sprintf\|substr\|uc\%(first\)\=\)\>"
 syn match perlStatementRegexp		"\<\%(pos\|quotemeta\|split\|study\)\>"
 syn match perlStatementNumeric		"\<\%(abs\|atan2\|cos\|exp\|hex\|int\|log\|oct\|rand\|sin\|sqrt\|srand\)\>"
 syn match perlStatementList		"\<\%(splice\|unshift\|shift\|push\|pop\|join\|reverse\|grep\|map\|sort\|unpack\)\>"
@@ -94,7 +94,7 @@ syn match perlStatementFiledesc		"\<\%(fcntl\|flock\|ioctl\|open\%(dir\)\=\|read
 syn match perlStatementVector		"\<vec\>"
 syn match perlStatementFiles		"\<\%(ch\%(dir\|mod\|own\|root\)\|glob\|link\|mkdir\|readlink\|rename\|rmdir\|symlink\|umask\|unlink\|utime\)\>"
 syn match perlStatementFiles		"-[rwxoRWXOezsfdlpSbctugkTBMAC]\>"
-syn match perlStatementFlow		"\<\%(caller\|die\|dump\|eval\|exit\|wantarray\|evalbytes\)\>"
+syn match perlStatementFlow		"\<\%(caller\|die\|dump\|eval\|exit\|wantarray\)\>"
 syn match perlStatementInclude		"\<\%(require\|import\)\>"
 syn match perlStatementInclude		"\<\%(use\|no\)\s\+\%(\%(attributes\|attrs\|autouse\|parent\|base\|big\%(int\|num\|rat\)\|blib\|bytes\|charnames\|constant\|diagnostics\|encoding\%(::warnings\)\=\|feature\|fields\|filetest\|if\|integer\|less\|lib\|locale\|mro\|open\|ops\|overload\|re\|sigtrap\|sort\|strict\|subs\|threads\%(::shared\)\=\|utf8\|vars\|version\|vmsish\|warnings\%(::register\)\=\)\>\)\="
 syn match perlStatementProc		"\<\%(alarm\|exec\|fork\|get\%(pgrp\|ppid\|priority\)\|kill\|pipe\|set\%(pgrp\|priority\)\|sleep\|system\|times\|wait\%(pid\)\=\)\>"
@@ -375,20 +375,9 @@ syn match perlFunction +\<sub\>\_s*+ nextgroup=perlSubName
 " a string
 syn match  perlString "\I\@<!-\?\I\i*\%(\s*=>\)\@="
 
-" perlcritic comments
-hi def link perlCritic PreProc
-syn match perlCritic "\%(#[^#]*\)\@<!#\zs#\s*no\s\+critic\s*\%(qw\|\)\%(([a-zA-Z0-9,: ]*)\|\)\ze"
-syn match perlCritic "\%(#[^#]*\)\@<!#\zs#\s*use\s\+critic\ze"
-syn match perlComment "#.*" contains=perlTodo,perlCritic,@Spell
-
-" perltidy comments, always MUST be placed after "syn match perlComment" definition
-hi def link perlTidyComment Comment
-hi def link perlTidy PreProc
-syn match perlTidy "^\s*#\zs\%(<<<\|>>>\)\ze"
-syn match perlTidyComment "^\s*#\%(<<<\|>>>\).*" contains=perlTidy,@Spell
-
-" perlSharpBang, always MUST be placed after "syn match perlTidyComment" definition
-syn match perlSharpBang "^#!.*"
+" All other # are comments, except ^#!
+syn match  perlComment    "#.*" contains=perlTodo,@Spell extend
+syn match  perlSharpBang  "^#!.*"
 
 " Formats
 syn region perlFormat		matchgroup=perlStatementIOFunc start="^\s*\<format\s\+\k\+\s*=\s*$"rs=s+6 end="^\s*\.\s*$" contains=perlFormatName,perlFormatField,perlVarPlain,perlVarPlain2


### PR DESCRIPTION
1. support for highlight PerlCritic comment, such as:
   ## use critic 
   ## no critic
   ## no critic  qw(....)
   ## no critic ()
2. Highlight PerlTidy comments: #<<<, #>>>
3. Fixed several bugs in anonymous subs folding, when sub was folded incorrectly if contains comments with "}". Now works as it should.
4. New keywords, fs and evalbytes added;
