### PR TITLE
Fix highlighting for function name after print.

### DIFF
--- a/syntax/perl.vim
+++ b/syntax/perl.vim
@@ -176,10 +176,10 @@ endif
 " File Descriptors
 syn match  perlFiledescRead	"<\h\w*>"
 
-syn match  perlFiledescStatementComma	"(\=\s*\u\w*\s*,"me=e-1 transparent contained contains=perlFiledescStatement
-syn match  perlFiledescStatementNocomma "(\=\s*\u\w*\s*[^, \t]"me=e-1 transparent contained contains=perlFiledescStatement
+syn match  perlFiledescStatementComma	"(\=\s*\<\u\w*\>\s*,"me=e-1 transparent contained contains=perlFiledescStatement
+syn match  perlFiledescStatementNocomma "(\=\s*\<\u\w*\>\s*[^, \t]"me=e-1 transparent contained contains=perlFiledescStatement
 
-syn match  perlFiledescStatement	"\u\w*" contained
+syn match  perlFiledescStatement	"\<\u\w*\>" contained
 
 " Special characters in strings and matches
 syn match  perlSpecialString	"\\\%(\o\{1,3}\|x\%({\x\+}\|\x\{1,2}\)\|c.\|[^cx]\)" contained extend


### PR DESCRIPTION
Previously, "Foo" was highlighted in the following:

  print Foo::Bar::baz();

When trying to match a bareword as a filehandle, ensure that the match ends at
the end of a keyword to rule out accidentally matching the beginning part of a
fully-qualified function name.

This does result in three differences in the corpus; however, they are all exactly this case and they are now correctly highlighted. I happened to notice this today at work because we use a lot of fully-qualified function names.
