### PR TITLE
Add perl_no_subprototype_error for perl's new feature 'signatures'

### DIFF
--- a/syntax/perl.vim
+++ b/syntax/perl.vim
@@ -365,8 +365,10 @@ else
     syn match perlSubAttributes "" contained nextgroup=perlSubError
     syn match perlSubAttributes ":\_s*" contained nextgroup=@perlSubAttrMaybe
 endif
-syn match perlSubPrototypeError "(\%(\_s*\%(\%(\\\%([$@%&*]\|\[[$@%&*]\+\]\)\|[$&*]\|[@%]\%(\_s*)\)\@=\|;\%(\_s*[)$@%&*\\]\)\@=\|_\%(\_s*[);]\)\@=\)\_s*\)*\)\@>\zs\_[^)]\+" contained
-syn match perlSubPrototype +(\_[^)]*)\_s*\|+ nextgroup=perlSubAttributes,perlComment contained contains=perlSubPrototypeError
+if !exists("perl_no_subprototype_error") " Set 1 if using signatures feature in perl5.19.9
+    syn match perlSubPrototypeError "(\%(\_s*\%(\%(\\\%([$@%&*]\|\[[$@%&*]\+\]\)\|[$&*]\|[@%]\%(\_s*)\)\@=\|;\%(\_s*[)$@%&*\\]\)\@=\|_\%(\_s*[);]\)\@=\)\_s*\)*\)\@>\zs\_[^)]\+" contained
+    syn match perlSubPrototype +(\_[^)]*)\_s*\|+ nextgroup=perlSubAttributes,perlComment contained contains=perlSubPrototypeError
+endif
 syn match perlSubName +\%(\h\|::\|'\w\)\%(\w\|::\|'\w\)*\_s*\|+ contained nextgroup=perlSubPrototype,perlComment
 
 syn match perlFunction +\<sub\>\_s*+ nextgroup=perlSubName


### PR DESCRIPTION
perl 5.19.9 included signatures feature, and it will be released on 5.20 .
This feature break syntax of sub-routine prototype. For example, signatures allow to be writen like follow.

``` perl
sub foo($class, $a, $b = sub(){ warn "foo" }) {
  # ...
}
```
