### PR TITLE
Fix mishighlighting of lines containing heredoc markers.

### DIFF
--- a/syntax/perl.vim
+++ b/syntax/perl.vim
@@ -329,19 +329,24 @@ syn region perlQQ		matchgroup=perlStringStartEnd start=+\<\%(::\|'\|->\)\@<!qr\s
 " XXX Any statements after the identifier are in perlString colour (i.e.
 " 'if $a' in 'print <<EOF if $a'). This is almost impossible to get right it
 " seems due to the 'auto-extending nature' of regions.
+syn region perlHereDocStart	matchgroup=perlStringStartEnd start=+<<\z(\I\i*\)+  end=+$+     contains=@perlTop oneline
+syn region perlHereDocStart	matchgroup=perlStringStartEnd start=+<<\s*"\z([^\\"]*\%(\\.[^\\"]*\)*\)"+ end=+$+ contains=@perlTop oneline
+syn region perlHereDocStart	matchgroup=perlStringStartEnd start=+<<\s*'\z([^\\']*\%(\\.[^\\']*\)*\)'+ end=+$+ contains=@perlTop oneline
+syn region perlHereDocStart	matchgroup=perlStringStartEnd start=+<<\s*""+       end=+$+     contains=@perlTop oneline
+syn region perlHereDocStart	matchgroup=perlStringStartEnd start=+<<\s*''+       end=+$+     contains=@perlTop oneline
 if exists("perl_fold")
-  syn region perlHereDoc	matchgroup=perlStringStartEnd start=+<<\z(\I\i*\).*+    end=+^\z1$+ contains=@perlInterpDQ fold extend
-  syn region perlHereDoc	matchgroup=perlStringStartEnd start=+<<\s*"\z([^\\"]*\%(\\.[^\\"]*\)*\)"+ end=+^\z1$+ contains=@perlInterpDQ fold extend
-  syn region perlHereDoc	matchgroup=perlStringStartEnd start=+<<\s*'\z([^\\']*\%(\\.[^\\']*\)*\)'+ end=+^\z1$+ contains=@perlInterpSQ fold extend
-  syn region perlHereDoc	matchgroup=perlStringStartEnd start=+<<\s*""+           end=+^$+    contains=@perlInterpDQ,perlNotEmptyLine fold extend
-  syn region perlHereDoc	matchgroup=perlStringStartEnd start=+<<\s*''+           end=+^$+    contains=@perlInterpSQ,perlNotEmptyLine fold extend
+  syn region perlHereDoc	start=+<<\z(\I\i*\)+ matchgroup=perlStringStartEnd      end=+^\z1$+ contains=perlHereDocStart,@perlInterpDQ fold extend
+  syn region perlHereDoc	start=+<<\s*"\z([^\\"]*\%(\\.[^\\"]*\)*\)"+ matchgroup=perlStringStartEnd end=+^\z1$+ contains=perlHereDocStart,@perlInterpDQ fold extend
+  syn region perlHereDoc	start=+<<\s*'\z([^\\']*\%(\\.[^\\']*\)*\)'+ matchgroup=perlStringStartEnd end=+^\z1$+ contains=perlHereDocStart,@perlInterpSQ fold extend
+  syn region perlHereDoc	start=+<<\s*""+ matchgroup=perlStringStartEnd           end=+^$+    contains=perlHereDocStart,@perlInterpDQ,perlNotEmptyLine fold extend
+  syn region perlHereDoc	start=+<<\s*''+ matchgroup=perlStringStartEnd           end=+^$+    contains=perlHereDocStart,@perlInterpSQ,perlNotEmptyLine fold extend
   syn region perlAutoload	matchgroup=perlStringStartEnd start=+<<\s*\(['"]\=\)\z(END_\%(SUB\|OF_FUNC\|OF_AUTOLOAD\)\)\1+ end=+^\z1$+ contains=ALL fold extend
 else
-  syn region perlHereDoc	matchgroup=perlStringStartEnd start=+<<\z(\I\i*\).*+    end=+^\z1$+ contains=@perlInterpDQ
-  syn region perlHereDoc	matchgroup=perlStringStartEnd start=+<<\s*"\z([^\\"]*\%(\\.[^\\"]*\)*\)"+ end=+^\z1$+ contains=@perlInterpDQ
-  syn region perlHereDoc	matchgroup=perlStringStartEnd start=+<<\s*'\z([^\\']*\%(\\.[^\\']*\)*\)'+ end=+^\z1$+ contains=@perlInterpSQ
-  syn region perlHereDoc	matchgroup=perlStringStartEnd start=+<<\s*""+           end=+^$+    contains=@perlInterpDQ,perlNotEmptyLine
-  syn region perlHereDoc	matchgroup=perlStringStartEnd start=+<<\s*''+           end=+^$+    contains=@perlInterpSQ,perlNotEmptyLine
+  syn region perlHereDoc	start=+<<\z(\I\i*\)+ matchgroup=perlStringStartEnd      end=+^\z1$+ contains=perlHereDocStart,@perlInterpDQ
+  syn region perlHereDoc	start=+<<\s*"\z([^\\"]*\%(\\.[^\\"]*\)*\)"+ matchgroup=perlStringStartEnd end=+^\z1$+ contains=perlHereDocStart,@perlInterpDQ
+  syn region perlHereDoc	start=+<<\s*'\z([^\\']*\%(\\.[^\\']*\)*\)'+ matchgroup=perlStringStartEnd end=+^\z1$+ contains=perlHereDocStart,@perlInterpSQ
+  syn region perlHereDoc	start=+<<\s*""+ matchgroup=perlStringStartEnd           end=+^$+    contains=perlHereDocStart,@perlInterpDQ,perlNotEmptyLine
+  syn region perlHereDoc	start=+<<\s*''+ matchgroup=perlStringStartEnd           end=+^$+    contains=perlHereDocStart,@perlInterpSQ,perlNotEmptyLine
   syn region perlAutoload	matchgroup=perlStringStartEnd start=+<<\s*\(['"]\=\)\z(END_\%(SUB\|OF_FUNC\|OF_AUTOLOAD\)\)\1+ end=+^\z1$+ contains=ALL
 endif
 

--- a/t_source/perl/advanced.t.html
+++ b/t_source/perl/advanced.t.html
@@ -39,28 +39,28 @@
 <span class="synComment"># depending on whether perl_string_as_statement is set.</span>
 <span class="synComment"># </span><span class="synTodo">XXX</span><span class="synComment"> 'if $true' is highlighted incorrectly</span>
 <span class="synIdentifier">$true</span> = <span class="synNumber">1</span>;
-<span class="synStatement">print</span> <span class="synString">&lt;&lt;EOF if $true;</span>
+<span class="synStatement">print</span> <span class="synString">&lt;&lt;EOF</span><span class="synperlHereDocStart"> </span><span class="synConditional">if</span><span class="synperlHereDocStart"> </span><span class="synIdentifier">$true</span><span class="synperlHereDocStart">;</span>
 <span class="synString">Here document</span>
 <span class="synString">EOF</span>
-<span class="synStatement">print</span> <span class="synString">&lt;&lt;&quot;EOF&quot; if </span><span class="synIdentifier">$true</span><span class="synString">;</span>
+<span class="synStatement">print</span> <span class="synString">&lt;&lt;&quot;EOF&quot;</span><span class="synperlHereDocStart"> </span><span class="synConditional">if</span><span class="synperlHereDocStart"> </span><span class="synIdentifier">$true</span><span class="synperlHereDocStart">;</span>
 <span class="synString">Here document</span>
 <span class="synString">EOF</span>
-<span class="synStatement">print</span> <span class="synString">&lt;&lt;'EOF' if $true;</span>
+<span class="synStatement">print</span> <span class="synString">&lt;&lt;'EOF'</span><span class="synperlHereDocStart"> </span><span class="synConditional">if</span><span class="synperlHereDocStart"> </span><span class="synIdentifier">$true</span><span class="synperlHereDocStart">;</span>
 <span class="synString">Here document</span>
 <span class="synString">EOF</span>
 
 <span class="synComment"># Here documents finishing with an empty line. Note the Error colour because of</span>
 <span class="synComment"># the line with only a space in it.</span>
-<span class="synStatement">print</span> <span class="synString">&lt;&lt;&quot;&quot; if </span><span class="synIdentifier">$true</span><span class="synString">;</span>
+<span class="synStatement">print</span> <span class="synString">&lt;&lt;&quot;&quot;</span><span class="synperlHereDocStart"> </span><span class="synConditional">if</span><span class="synperlHereDocStart"> </span><span class="synIdentifier">$true</span><span class="synperlHereDocStart">;</span>
 <span class="synString">Here document</span>
 <span class="synError"> </span>
 
-<span class="synStatement">print</span> <span class="synString">&lt;&lt;'' if $true;</span>
+<span class="synStatement">print</span> <span class="synString">&lt;&lt;''</span><span class="synperlHereDocStart"> </span><span class="synConditional">if</span><span class="synperlHereDocStart"> </span><span class="synIdentifier">$true</span><span class="synperlHereDocStart">;</span>
 <span class="synString">Here document</span>
 <span class="synError"> </span>
 
 <span class="synComment"># Here document with a different. Only works in 6.0.</span>
-<span class="synStatement">print</span> <span class="synString">&lt;&lt;RandomID;</span>
+<span class="synStatement">print</span> <span class="synString">&lt;&lt;RandomID</span><span class="synperlHereDocStart">;</span>
 <span class="synString">here document</span>
 <span class="synString">RandomID</span>
 

--- a/t_source/perl/brace-in-substitution.t.html
+++ b/t_source/perl/brace-in-substitution.t.html
@@ -15,7 +15,7 @@
 <span class="synKeyword">sub </span><span class="synFunction">test_sub </span>{
     <span class="synStatement">my</span> ( <span class="synIdentifier">$dbh</span> ) = <span class="synIdentifier">@_</span>;
 
-    <span class="synStatement">my</span> <span class="synIdentifier">$sql_template</span> = <span class="synString">&lt;&lt;'END_SQL';</span>
+    <span class="synStatement">my</span> <span class="synIdentifier">$sql_template</span> = <span class="synString">&lt;&lt;'END_SQL'</span><span class="synperlHereDocStart">;</span>
 <span class="synString">SELECT {{COLUMNS}} FROM MyTable</span>
 <span class="synString">END_SQL</span>
 

--- a/t_source/perl/braces-in-heredoc.t.html
+++ b/t_source/perl/braces-in-heredoc.t.html
@@ -12,7 +12,7 @@
 <span class="synStatement">use warnings</span>;
 
 <span class="synKeyword">sub </span><span class="synFunction">foo </span>{
-    <span class="synStatement">my</span> <span class="synIdentifier">$x</span> = <span class="synString">&lt;&lt;'PERL';</span>
+    <span class="synStatement">my</span> <span class="synIdentifier">$x</span> = <span class="synString">&lt;&lt;'PERL'</span><span class="synperlHereDocStart">;</span>
 <span class="synString">sub func1 {</span>
 <span class="synString">    print 'In a heredoc';</span>
 <span class="synString">} # Syntax highlighting things this brace closes foo()'s body</span>

--- a/t_source/perl/issue48.t.html
+++ b/t_source/perl/issue48.t.html
@@ -11,12 +11,12 @@
 <span class="synStatement">use strict</span>;
 <span class="synStatement">use warnings</span>;
 
-<span class="synStatement">print</span> <span class="synIdentifier">@{</span><span class="synperlVarBlock"> </span><span class="synIdentifier">$dbh-&gt;selectrow_arrayref</span><span class="synperlVarBlock">(</span><span class="synString">&lt;&lt;SQL) };</span>
+<span class="synStatement">print</span> <span class="synIdentifier">@{</span><span class="synperlVarBlock"> </span><span class="synIdentifier">$dbh-&gt;selectrow_arrayref</span><span class="synperlVarBlock">(</span><span class="synString">&lt;&lt;SQL</span><span class="synperlHereDocStart">) };</span>
 <span class="synString">SELECT s[site_hum_id</span>
 <span class="synString">  FROM site_inst s</span>
 <span class="synString">SQL</span>
 
-<span class="synStatement">print</span> <span class="synIdentifier">%{</span><span class="synperlVarBlock2"> </span><span class="synIdentifier">$dbh-&gt;selectrow_arrayref</span><span class="synperlVarBlock2">(</span><span class="synString">&lt;&lt;SQL) };</span>
+<span class="synStatement">print</span> <span class="synIdentifier">%{</span><span class="synperlVarBlock2"> </span><span class="synIdentifier">$dbh-&gt;selectrow_arrayref</span><span class="synperlVarBlock2">(</span><span class="synString">&lt;&lt;SQL</span><span class="synperlHereDocStart">) };</span>
 <span class="synString">SELECT s[site_hum_id</span>
 <span class="synString">  FROM site_inst s</span>
 <span class="synString">SQL</span>

--- a/t_source/perl/issue52.t.html
+++ b/t_source/perl/issue52.t.html
@@ -13,7 +13,7 @@
 
 <span class="synStatement">package</span><span class="synType"> main</span>;
 
-<span class="synStatement">my</span> <span class="synIdentifier">$example</span> = <span class="synString">&lt;&lt;EOF;</span>
+<span class="synStatement">my</span> <span class="synIdentifier">$example</span> = <span class="synString">&lt;&lt;EOF</span><span class="synperlHereDocStart">;</span>
 <span class="synString">quoted like it should be.</span>
 <span class="synString">package except everything after this line, because it begins with package.</span>
 <span class="synString">EOF</span>


### PR DESCRIPTION
Previously, the part of a line after a heredoc marker ended up being highlighted as a string.  Adjust the highlighting so that the remainder of the line is highlighted as normal.  Modify the expected output for
the t/01_highlighting tests such that they are now correct.

While this updates the t/01_highlighting tests, it doesn't update the corpus tests because those explicitly direct the maintainer to update them.  If you'd like me to adjust them as well, please let me know.

I used the same technique as is used in the vim-ruby repository, because I noticed they didn't have this problem. There might be other, simpler ways to go about it, but I felt this was likely to be fairly robust considering that the Ruby people have been using it for some time.

Essentially, the technique is that `perlHereDocStart` is highlighted as Normal (since that's the default) and it passes through other top-level highlighting to make it work. The matchgroup part for `perlHereDoc` has to be after the start part, or it doesn't fix the problem.

Fixes #8.