### PR TITLE
Fix perl ftplugins: undo_ftplugin and path appending

### DIFF
--- a/ftplugin/perl.vim
+++ b/ftplugin/perl.vim
@@ -77,7 +77,7 @@ endif
 "---------------------------------------------
 
 " Undo the stuff we changed.
-let b:undo_ftplugin = "setlocal fo< com< cms< inc< inex< def< isf< kp< path<" .
+let b:undo_ftplugin = "setlocal fo< com< cms< inc< inex< def< isk< isf< kp< path<" .
 	    \	      " | unlet! b:browsefilter"
 
 " proper matching for matchit plugin

--- a/ftplugin/perl6.vim
+++ b/ftplugin/perl6.vim
@@ -65,7 +65,18 @@ if !exists("perlpath")
     endif
 endif
 
-let &l:path=perlpath
+" Append perlpath to the existing path value, if it is set.  Since we don't
+" use += to do it because of the commas in perlpath, we have to handle the
+" global / local settings, too.
+if &l:path == ""
+    if &g:path == ""
+        let &l:path=perlpath
+    else
+        let &l:path=&g:path.",".perlpath
+    endif
+else
+    let &l:path=&l:path.",".perlpath
+endif
 "---------------------------------------------
 
 " Undo the stuff we changed.

--- a/ftplugin/perl6.vim
+++ b/ftplugin/perl6.vim
@@ -69,7 +69,7 @@ let &l:path=perlpath
 "---------------------------------------------
 
 " Undo the stuff we changed.
-let b:undo_ftplugin = "setlocal fo< com< cms< inc< inex< def< isk<" .
+let b:undo_ftplugin = "setlocal fo< com< cms< inc< inex< def< isf< isk< kp< path<" .
         \         " | unlet! b:browsefilter"
 
 " Restore the saved compatibility options.


### PR DESCRIPTION
I don't really see why there are two separate ftplugins for perl and perl6 (perl6 might source perl instead).

But I've noticed that `'path'` is not cleaned up properly.