### PR TITLE
Not indenting comments

### DIFF
--- a/indent/perl.vim
+++ b/indent/perl.vim
@@ -48,11 +48,6 @@ function! GetPerlIndent()
         return 0
     endif
 
-    " Don't reindent comments on first column
-    if cline =~ '^#.'
-        return 0
-    endif
-
     " Get current syntax item at the line's first char
     let csynid = ''
     if b:indent_use_syntax

--- a/indent/perl6.vim
+++ b/indent/perl6.vim
@@ -60,11 +60,6 @@ function! GetPerl6Indent()
         return 0
     endif
 
-    " Don't reindent comments on first column
-    if cline =~ '^#'
-        return 0
-    endif
-
     " Get current syntax item at the line's first char
     let csynid = ''
     if b:indent_use_syntax


### PR DESCRIPTION
It has been like this forever apparently, but I think https://github.com/vim-perl/vim-perl/blob/7ba0695/indent/perl.vim#L51-L54 is a bug.

If I indent this code with `=`:
```perl
if (1 == 1) {
# Unindented code
other_command();
}
```

I expect it to become:
```perl
if (1 == 1) {
  # How it should be indented
  other_command();
}
```

but it actually becomes:
```perl
if (1 == 1) {
# Makes no sense in Perl
  other_command();
}
```

I think this comes form C [pragmas](https://en.wikipedia.org/wiki/Directive_%28programming%29) but that makes no sense in Perl since in Perl pragmas are in the form of `use strict;` e.g.

What have I missed?