### PR TITLE
highlight return-rw for returning is-rw containers

### DIFF
--- a/syntax/perl6.vim
+++ b/syntax/perl6.vim
@@ -85,8 +85,8 @@ let s:keywords = {
  \   "for loop repeat while until gather given",
  \ ],
  \ "p6FlowControl": [
- \   "take do when next last redo return contend maybe defer start",
- \   "default exit make continue break goto leave async lift",
+ \   "take do when next last redo return return-rw contend maybe defer",
+ \   "start default exit make continue break goto leave async lift",
  \ ],
  \ "p6ClosureTrait": [
  \   "BEGIN CHECK INIT START FIRST ENTER LEAVE KEEP",

--- a/syntax/perl6.vim.pre
+++ b/syntax/perl6.vim.pre
@@ -85,8 +85,8 @@ let s:keywords = {
  \   "for loop repeat while until gather given",
  \ ],
  \ "p6FlowControl": [
- \   "take do when next last redo return contend maybe defer start",
- \   "default exit make continue break goto leave async lift",
+ \   "take do when next last redo return return-rw contend maybe defer",
+ \   "start default exit make continue break goto leave async lift",
  \ ],
  \ "p6ClosureTrait": [
  \   "BEGIN CHECK INIT START FIRST ENTER LEAVE KEEP",


### PR DESCRIPTION
http://doc.perl6.org/language/containers

> For explicit returns, `return-rw` instead of `return` must be used.