### PR TITLE
Allow indented SQL heredoc marker

### DIFF
--- a/contrib/heredoc-sql.vim
+++ b/contrib/heredoc-sql.vim
@@ -10,11 +10,11 @@ unlet b:current_syntax
 syntax include @SQL syntax/sql.vim
 
 if get(g:, 'perl_fold', 0)
-  syntax region perlHereDocSQL matchgroup=perlStringStartEnd start=+<<\s*'\z(\%(END_\)\=SQL\)'+ end='^\z1$' contains=@SQL               fold extend
-  syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\s*"\z(\%(END_\)\=SQL\)"' end='^\z1$' contains=@perlInterpDQ,@SQL fold extend
+  syntax region perlHereDocSQL matchgroup=perlStringStartEnd start=+<<\s*'\z(\s*\%(END_\)\=SQL\)'+ end='^\z1$' contains=@SQL               fold extend
+  syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\s*"\z(\s*\%(END_\)\=SQL\)"' end='^\z1$' contains=@perlInterpDQ,@SQL fold extend
   syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\s*\z(\%(END_\)\=SQL\)'   end='^\z1$' contains=@perlInterpDQ,@SQL fold extend
 else
-  syntax region perlHereDocSQL matchgroup=perlStringStartEnd start=+<<\s*'\z(\%(END_\)\=SQL\)'+ end='^\z1$' contains=@SQL
-  syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\s*"\z(\%(END_\)\=SQL\)"' end='^\z1$' contains=@perlInterpDQ,@SQL
+  syntax region perlHereDocSQL matchgroup=perlStringStartEnd start=+<<\s*'\z(\s*\%(END_\)\=SQL\)'+ end='^\z1$' contains=@SQL
+  syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\s*"\z(\s*\%(END_\)\=SQL\)"' end='^\z1$' contains=@perlInterpDQ,@SQL
   syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\s*\z(\%(END_\)\=SQL\)'   end='^\z1$' contains=@perlInterpDQ,@SQL
 endif


### PR DESCRIPTION
In properly indented code it is nicer to be able to do

```
    my $a = << "    SQL"
        SELECT something FROM somewhere
    SQL
```

avoiding the need to put the second 'SQL' without whitespace prefix, but this requires the inclusion of the white space in the here document terminator.
