### PR TITLE
Add 'subtest' to the test-more list

### DIFF
--- a/contrib/test-more.vim
+++ b/contrib/test-more.vim
@@ -3,4 +3,4 @@
 " Installation: Put into after/syntax/perl/test-more.vim
 
 " XXX include guard
-syntax match perlStatementProc "\<\%(plan\|use_ok\|require_ok\|ok\|is\|isnt\|diag\|like\|unlike\|cmp_ok\|is_deeply\|skip\|can_ok\|isa_ok\|pass\|fail\|BAIL_OUT\)\>"
+syntax match perlStatementProc "\<\%(plan\|use_ok\|require_ok\|ok\|is\|isnt\|diag\|like\|unlike\|cmp_ok\|is_deeply\|skip\|can_ok\|isa_ok\|pass\|fail\|BAIL_OUT\|subtest\)\>"

--- a/contrib/test-more.vim
+++ b/contrib/test-more.vim
@@ -3,4 +3,4 @@
 " Installation: Put into after/syntax/perl/test-more.vim
 
 " XXX include guard
-syntax match perlStatementProc "\<\%(plan\|use_ok\|require_ok\|ok\|is\|isnt\|diag\|like\|unlike\|cmp_ok\|is_deeply\|skip\|can_ok\|isa_ok\|pass\|fail\|BAIL_OUT\|subtest\)\>"
+syntax match perlStatementProc "\<\%(plan\|use_ok\|require_ok\|ok\|is\|isnt\|diag\|explain\|note\|like\|unlike\|cmp_ok\|is_deeply\|skip\|can_ok\|isa_ok\|pass\|fail\|BAIL_OUT\|subtest\)\>"


### PR DESCRIPTION
Add 'subtest' to the list of Test::More functions, so it's highlighted
in the same way as 'plan', 'is', et al.
