### PR TITLE
Allow indent to cuddle tabs when multiple opening braces are on the same line.

### DIFF
--- a/indent/perl.vim
+++ b/indent/perl.vim
@@ -25,7 +25,15 @@
 " opening brace.  
 "
 " If you want to collapse the indents for cuddled braces then:
-" let g:PerlCuddleIndent = 1
+" let g:perl_cuddle_indent = 1
+" Eg:
+" $foo = [{
+"     key => $val
+" }]
+" Without perl_cuddle_indent you get:
+" $foo = [{
+"         key => $val
+"     }]
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -147,7 +155,7 @@ function! GetPerlIndent()
                 endif
             endif
 
-            if exists('g:PerlCuddleIndent') && g:PerlCuddleIndent
+            if exists('g:perl_cuddle_indent') && g:perl_cuddle_indent
                 let bracepos = -1
             else
                 let bracepos = match(line, braceclass, bracepos + 1)

--- a/indent/perl.vim
+++ b/indent/perl.vim
@@ -19,6 +19,13 @@
 " (The following probably needs modifying the perl syntax file)
 " - qw() lists
 " - Heredocs with terminators that don't match \I\i*
+"
+" If multiple opening braces are on the same line, then
+" normal behavior is to indent over one shift width per 
+" opening brace.  
+"
+" If you want to collapse the indents for cuddled braces then:
+" let g:PerlCuddleIndent = 1
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -139,7 +146,12 @@ function! GetPerlIndent()
                     let ind = ind - &sw
                 endif
             endif
-            let bracepos = match(line, braceclass, bracepos + 1)
+
+            if exists('g:PerlCuddleIndent') && g:PerlCuddleIndent
+                let bracepos = -1
+            else
+                let bracepos = match(line, braceclass, bracepos + 1)
+            endif
         endwhile
         let bracepos = matchend(cline, '^\s*[])}]')
         if bracepos != -1


### PR DESCRIPTION
This is in response to #210.  It introduces a new variable (perl_cuddle_indent) that when set will collapse tabs for multiple opening braces.  I wasn't sure if I wanted to make this behavior depend on a variable, but perhaps some like the current style.

@hoelzro has a similar fix [here](https://github.com/hoelzro/vimfiles/commit/f8bab0eb12441fbd4274984223dd6ee6a8859499)

I'm also not super fond of the variable name. :)