### PR TITLE
Fix indent for shiftwidth=0

### DIFF
--- a/indent/perl.vim
+++ b/indent/perl.vim
@@ -38,16 +38,6 @@ endif
 let s:cpo_save = &cpo
 set cpo-=C
 
-if exists('*shiftwidth')
-  function! s:sw()
-    return shiftwidth()
-  endfunction
-else
-  function! s:sw()
-    return &shiftwidth
-  endfunction
-endif
-
 function! GetPerlIndent()
 
     " Get the line to be indented
@@ -144,9 +134,9 @@ function! GetPerlIndent()
                         \ || synid =~ '^perl\(Sub\|Block\|Package\)Fold'
                 let brace = strpart(line, bracepos, 1)
                 if brace == '(' || brace == '{' || brace == '['
-                    let ind = ind + s:sw()
+                    let ind = ind + shiftwidth()
                 else
-                    let ind = ind - s:sw()
+                    let ind = ind - shiftwidth()
                 endif
             endif
             let bracepos = match(line, braceclass, bracepos + 1)
@@ -159,25 +149,25 @@ function! GetPerlIndent()
                         \ || synid == "perlBraces"
                         \ || synid == "perlStatementIndirObj"
                         \ || synid =~ '^perl\(Sub\|Block\|Package\)Fold'
-                let ind = ind - s:sw()
+                let ind = ind - shiftwidth()
             endif
         endif
     else
         if line =~ '[{[(]\s*\(#[^])}]*\)\=$'
-            let ind = ind + s:sw()
+            let ind = ind + shiftwidth()
         endif
         if cline =~ '^\s*[])}]'
-            let ind = ind - s:sw()
+            let ind = ind - shiftwidth()
         endif
     endif
 
     " Indent lines that begin with 'or' or 'and'
     if cline =~ '^\s*\(or\|and\)\>'
         if line !~ '^\s*\(or\|and\)\>'
-            let ind = ind + s:sw()
+            let ind = ind + shiftwidth()
         endif
     elseif line =~ '^\s*\(or\|and\)\>'
-        let ind = ind - s:sw()
+        let ind = ind - shiftwidth()
     endif
 
     return ind

--- a/indent/perl.vim
+++ b/indent/perl.vim
@@ -38,6 +38,16 @@ endif
 let s:cpo_save = &cpo
 set cpo-=C
 
+if exists('*shiftwidth')
+  function! s:sw()
+    return shiftwidth()
+  endfunction
+else
+  function! s:sw()
+    return &shiftwidth
+  endfunction
+endif
+
 function! GetPerlIndent()
 
     " Get the line to be indented
@@ -134,9 +144,9 @@ function! GetPerlIndent()
                         \ || synid =~ '^perl\(Sub\|Block\|Package\)Fold'
                 let brace = strpart(line, bracepos, 1)
                 if brace == '(' || brace == '{' || brace == '['
-                    let ind = ind + &sw
+                    let ind = ind + s:sw()
                 else
-                    let ind = ind - &sw
+                    let ind = ind - s:sw()
                 endif
             endif
             let bracepos = match(line, braceclass, bracepos + 1)
@@ -149,25 +159,25 @@ function! GetPerlIndent()
                         \ || synid == "perlBraces"
                         \ || synid == "perlStatementIndirObj"
                         \ || synid =~ '^perl\(Sub\|Block\|Package\)Fold'
-                let ind = ind - &sw
+                let ind = ind - s:sw()
             endif
         endif
     else
         if line =~ '[{[(]\s*\(#[^])}]*\)\=$'
-            let ind = ind + &sw
+            let ind = ind + s:sw()
         endif
         if cline =~ '^\s*[])}]'
-            let ind = ind - &sw
+            let ind = ind - s:sw()
         endif
     endif
 
     " Indent lines that begin with 'or' or 'and'
     if cline =~ '^\s*\(or\|and\)\>'
         if line !~ '^\s*\(or\|and\)\>'
-            let ind = ind + &sw
+            let ind = ind + s:sw()
         endif
     elseif line =~ '^\s*\(or\|and\)\>'
-        let ind = ind - &sw
+        let ind = ind - s:sw()
     endif
 
     return ind


### PR DESCRIPTION
I use `set shiftwidth=0`. This is help for 'shiftwidth'.

    'shiftwidth' 'sw'       number  (default 8)
                            local to buffer
            Number of spaces to use for each step of (auto)indent.  Used for
            'cindent', >>, <<, etc.
            When zero the 'ts' value will be used.  Use the shiftwidth()
            function to get the effective shiftwidth value.

I added function `s:sw()` which is used in indent file for PHP.
https://github.com/2072/PHP-Indenting-for-VIm/blob/master/indent/php.vim#L401-L412