### PR TITLE
Use shiftwidth() instead of 'shiftwidth' option 

### DIFF
--- a/indent/perl6.vim
+++ b/indent/perl6.vim
@@ -102,19 +102,19 @@ function! GetPerl6Indent()
     endif
 
         if line =~ '[<«\[{(]\s*\(#[^)}\]»>]*\)\=$'
-            let ind = ind + &sw
+            let ind = ind + shiftwidth()
         endif
         if cline =~ '^\s*[)}\]»>]'
-            let ind = ind - &sw
+            let ind = ind - shiftwidth()
         endif
 
     " Indent lines that begin with 'or' or 'and'
     if cline =~ '^\s*\(or\|and\)\>'
         if line !~ '^\s*\(or\|and\)\>'
-            let ind = ind + &sw
+            let ind = ind + shiftwidth()
         endif
     elseif line =~ '^\s*\(or\|and\)\>'
-        let ind = ind - &sw
+        let ind = ind - shiftwidth()
     endif
 
     return ind


### PR DESCRIPTION
Same as #231, it should be applied to indent/perl6.vim too.

And, would you please send the latest indent plugins (perl.vim, perl6.vim) to Bram by mail?
The Vim runtime indent plugins are not up to date.
so currently `set sw=0` doesn't work.
ref. https://github.com/vim/vim/issues/1493