### PR TITLE
Beat podFormat into submission

### DIFF
--- a/syntax/pod.vim
+++ b/syntax/pod.vim
@@ -59,12 +59,14 @@ syn match podSpecial	"\(\<\|&\)\I\i*\(::\I\i*\)*([^)]*)" contains=@NoSpell
 syn match podSpecial	"[$@%]\I\i*\(::\I\i*\)*\>" contains=@NoSpell
 
 " Special formatting sequences
-syn region podFormat	start="[IBSCLFX]<[^<]"me=e-1 end=">" oneline contains=podFormat,@NoSpell
-syn region podFormat	start="[IBSCLFX]<<\s" end="\s>>" oneline contains=podFormat,@NoSpell
+syn region podFormat	start="[IBSCLFX]<<\s"  end="\s>>" oneline contains=podFormat,podFormatError,@NoSpell
+syn region podFormat	start="[IBSCLFX]<[^<]" end=">"    oneline contains=podFormat,podFormatError,@NoSpell
 syn match  podFormat	"Z<>"
 syn match  podFormat	"E<\(\d\+\|\I\i*\)>" contains=podEscape,podEscape2,@NoSpell
 syn match  podEscape	"\I\i*>"me=e-1 contained contains=@NoSpell
 syn match  podEscape2	"\d\+>"me=e-1 contained contains=@NoSpell
+
+syn match podFormatError "[IBSCLFXE]<>"
 
 " Define the default highlighting.
 " For version 5.7 and earlier: only when not done already
@@ -82,6 +84,7 @@ if version >= 508 || !exists("did_pod_syntax_inits")
   HiLink podOverIndent		Number
   HiLink podForKeywd		Identifier
   HiLink podFormat		Identifier
+  HiLink podFormatError		Error
   HiLink podVerbatimLine	PreProc
   HiLink podSpecial		Identifier
   HiLink podEscape		String


### PR DESCRIPTION
...kinda.

This is a revision of issue #237.  It properly constrains podFormat
regions to stay within their end pattern, largely by flipping the order
of the podFormat region definition lines *le sigh*.  We also drop the
irrelevant `me=...` offset, as `me` offsets are not
honored for start patterns.

We also define a new style, podFormatError, and use it to handle the
`I<>`/etc cases, making it unnecessary for us to muck around with the
start/end patterns.

Things not addressed: applying podFormatError to text inside podFormat
(e.g. `L<...>` done incorrectly) or to `I<< >>`-style sequences,
considering if we really want `@NoSpell`, etc.

This change causes the following POD to render correctly, at least for
me.  It seemed like a good place to start; I'll address any case not
caught if pointed out or discovered.

    If files are not specified for searching, either on the command
    line or piped in with the C<-x> option, I<ack> delves into
    subdirectories selecting files for searching.

    I<ack> is intelligent about the files it searches.  It knows about
    certain file types, based on both the extension on the file and,
    in some cases, the contents of the file.  These selections can be
    made with the B<--type> option.

    With no file selection, I<ack> searches through regular files that
    are not explicitly excluded by B<--ignore-dir> and B<--ignore-file>
    options, either present in F<ackrc> files or on the command line.
    ```

    B<I<Please>>?  And I<B<Please>> la la la
    B< I<Please>>?  And I<B<Please>> la la la
    B< I<Please>>?  And I<B<Please>> la la la
    B<< I<Please> >>?  And I<< B<< Please >> >> la la la

    beep E<acute> boop Z<> bap

    The I<> and B<> properly I<terminate> their highlighting, but the F<> and C<> do not.  At least on my setup.

    This should be podFormat then podFormatError: I<I<>> and I<< I<> >>, right?