### PR TITLE
Set `foldmethod=syntax` in the `ftplugin`, not `syntax`

### DIFF
--- a/ftplugin/perl.vim
+++ b/ftplugin/perl.vim
@@ -42,6 +42,10 @@ setlocal iskeyword+=:
 "       set isfname-=:
 set isfname+=:
 
+if get(g:, 'perl_fold', 1)
+  setlocal foldmethod=syntax
+endif
+
 " Set this once, globally.
 if !exists("perlpath")
     if executable("perl")

--- a/syntax/perl.vim
+++ b/syntax/perl.vim
@@ -425,7 +425,6 @@ if get(g:, 'perl_fold', 0)
     syn region perlBlockFold start="^\z(\s*\)\%(do\|else\)\%(\s*{\)\=\s*\%(#.*\)\=$" end="^\z1}\s*while" end="^\z1}\s*;\=\%(#.*\)\=$" transparent fold keepend
   endif
 
-  setlocal foldmethod=syntax
   syn sync fromstart
 else
   " fromstart above seems to set minlines even if perl_fold is not set.

--- a/tools/Local/VimFolds.pm
+++ b/tools/Local/VimFolds.pm
@@ -26,9 +26,10 @@ sub new {
     my ( $class, %params ) = @_;
 
     if(my $options = $params{'options'}) {
-        $params{'script_before'} = join(' | ', map {
-            "let $_=" . $options->{$_}
-        } keys %$options);
+        $params{'script_before'} = join(' | ',
+            'set foldmethod=syntax',
+            map { "let $_=" . $options->{$_} } keys %$options,
+        );
     }
 
     if(my $tty = $params{'debug_tty'}) {


### PR DESCRIPTION
...otherwise this causes surprising things to happen when the `perl` syntax is included as part of a different syntax and `g:perl_fold` is set.