### PR TITLE
Don't set syntax folding when perl_fold is unset

### DIFF
--- a/ftplugin/perl.vim
+++ b/ftplugin/perl.vim
@@ -43,7 +43,7 @@ setlocal iskeyword+=:
 "       set isfname-=:
 set isfname+=:
 
-if get(g:, 'perl_fold', 1)
+if get(g:, 'perl_fold', 0)
   setlocal foldmethod=syntax
 endif
 


### PR DESCRIPTION
This returns to behavior prior to 47fec445da1d8ff54ebcbf43ce73ed6bc8915cf3, where `setlocal foldmethod=syntax` moved from a default-0 condition block to a default-1 block.