### PR TITLE
Move the end of perlSubDeclaration

### DIFF
--- a/syntax/perl.vim
+++ b/syntax/perl.vim
@@ -387,7 +387,7 @@ else
 endif
 syn match perlSubAttribute "\s*:\s*\h\w*\%(([^)]*)\|\)" contained extend
 syn match perlSubName "\%(\h\|::\|'\w\)\%(\w\|::\|'\w\)*\s*" contained extend
-syn region perlSubDeclaration start="" end="[;{]" contains=perlSubName,perlSubPrototype,perlSubAttribute,perlSubSignature,perlComment contained transparent
+syn region perlSubDeclaration start="" end="[;{]"me=e-1 contains=perlSubName,perlSubPrototype,perlSubAttribute,perlSubSignature,perlComment contained transparent
 syn match perlFunction "\<sub\>\_s*" nextgroup=perlSubDeclaration
 
 " The => operator forces a bareword to the left of it to be interpreted as


### PR DESCRIPTION
issue https://github.com/vim-perl/vim-perl/issues/267

# Description

Indentation after `sub` doesn't work fine. I'm afraid that would be because the region of `perlSubDeclaration` in `syntax/perl.vim` not be appropriate, and indent by brace be invalidated.
The range should end just before the letter `{`, should not include `{` itself.

We could easily confirm it only by adding a line below into `indent/perl.vim`.

~~~perl
125         while bracepos != -1
126             let synid = synIDattr(synID(lnum, bracepos + 1, 0), "name")
127             echomsg "synid = " . synid       " <- add this line
~~~

(as-is)

~~~
sub main {<CR>
| <cursor
}
~~~

The result of `:messages`

~~~
synid = perlSubDeclaration
synid = perlSubDeclaration
~~~

(to-be)

~~~
sub main {<CR>
    | <cursor
}
~~~

~~~
synid = perlBraces
synid = perlBraces
~~~