### PR TITLE
Add an indent when synid is perlSubDeclaration

### DIFF
--- a/indent/perl.vim
+++ b/indent/perl.vim
@@ -133,6 +133,7 @@ function! GetPerlIndent()
                         \ || synid == "perlStatementIndirObj"
                         \ || synid =~ "^perlFiledescStatement"
                         \ || synid =~ '^perl\(Sub\|Block\|Package\)Fold'
+                        \ || synid == "perlSubDeclaration"
                 let brace = strpart(line, bracepos, 1)
                 if brace == '(' || brace == '{' || brace == '['
                     let ind = ind + shiftwidth()


### PR DESCRIPTION
issue #267 

# Description

Adds an indent when `synid` of opening brace is `perlSubDeclaration`.
It will fix the problem of the wrong indentation after `sub` mentioned at #267.

Once I created a PR  #280, but soon I withdrawn it because it introduced another problem about folding. 
It seems the problem would be caused by the reason that an opening brace of `sub` is recognized as `perlSubDeclaration`, which is not present in the condition of adding indent.

