### PR TITLE
tap.vim: Make "TODO" and "SKIP" case-insensitive

### DIFF
--- a/syntax/tap.vim
+++ b/syntax/tap.vim
@@ -29,12 +29,12 @@ syn match tapTestStatusOK /ok/ contained
 syn match tapTestStatusNotOK /not ok/ contained
 
 " highlight todo tests
-syn match tapTestTodo /\(# TODO\|Failed (TODO)\) .*$/ contained contains=tapTestTodoRev
-syn match tapTestTodoRev /\<TODO\>/ contained
+syn match tapTestTodo /\c\(# TODO\|Failed (TODO)\) .*$/ contained contains=tapTestTodoRev
+syn match tapTestTodoRev /\c\<TODO\>/ contained
 
 " highlight skipped tests
-syn match tapTestSkip /# skip .*$/ contained contains=tapTestSkipTag
-syn match tapTestSkipTag /\(# \)\@<=skip\>/ contained
+syn match tapTestSkip /\c# skip .*$/ contained contains=tapTestSkipTag
+syn match tapTestSkipTag /\c\(# \)\@<=skip\>/ contained
 
 " look behind so "ok 123" and "not ok 124" match test number
 syn match tapTestNumber /\(ok \)\@<=\d\d*/ contained


### PR DESCRIPTION
According to the TAP specification, the keywords "TODO" and "SKIP" are
case-insensitive:

    https://testanything.org/tap-specification.html#directives
    Directives are special notes that follow a # on the test line. Only
    two are currently defined: TODO and SKIP. Note that these two
    keywords are not case-sensitive.