### PR TITLE
Remove '+' from package names in includeexpr

### DIFF
--- a/ftplugin/perl.vim
+++ b/ftplugin/perl.vim
@@ -32,7 +32,7 @@ endif
 " Provided by Ned Konz <ned at bike-nomad dot com>
 "---------------------------------------------
 setlocal include=\\<\\(use\\\|require\\)\\>
-setlocal includeexpr=substitute(substitute(substitute(v:fname,'::','/','g'),'->\*','',''),'$','.pm','')
+setlocal includeexpr=substitute(substitute(substitute(substitute(v:fname,'+','',''),'::','/','g'),'->\*','',''),'$','.pm','')
 setlocal define=[^A-Za-z_]
 setlocal iskeyword+=:
 

--- a/ftplugin/perl.vim
+++ b/ftplugin/perl.vim
@@ -32,6 +32,8 @@ endif
 " Provided by Ned Konz <ned at bike-nomad dot com>
 "---------------------------------------------
 setlocal include=\\<\\(use\\\|require\\)\\>
+" '+' is removed to support plugins in Catalyst or DBIx::Class
+" where the leading plus indicates a fully-qualified module name.
 setlocal includeexpr=substitute(substitute(substitute(substitute(v:fname,'+','',''),'::','/','g'),'->\*','',''),'$','.pm','')
 setlocal define=[^A-Za-z_]
 setlocal iskeyword+=:


### PR DESCRIPTION
You often see a leading plus on package names in Catalyst. Not actually
valid anywhere in a package name so just remove one if we find it.