### PR TITLE
Add missing pragmas

### DIFF
--- a/syntax/perl.vim
+++ b/syntax/perl.vim
@@ -93,7 +93,7 @@ syn match perlStatementFiles		"\<\%(ch\%(dir\|mod\|own\|root\)\|glob\|link\|mkdi
 syn match perlStatementFiles		"-[rwxoRWXOezsfdlpSbctugkTBMAC]\>"
 syn match perlStatementFlow		"\<\%(caller\|die\|dump\|eval\|exit\|wantarray\|evalbytes\)\>"
 syn match perlStatementInclude		"\<\%(require\|import\|unimport\)\>"
-syn match perlStatementInclude		"\<\%(use\|no\)\s\+\%(\%(attributes\|attrs\|autodie\|autouse\|parent\|base\|big\%(int\|num\|rat\)\|blib\|bytes\|charnames\|constant\|diagnostics\|encoding\%(::warnings\)\=\|feature\|fields\|filetest\|if\|integer\|less\|lib\|locale\|mro\|open\|ops\|overload\|overloading\|re\|sigtrap\|sort\|strict\|subs\|threads\%(::shared\)\=\|utf8\|vars\|version\|vmsish\|warnings\%(::register\)\=\)\>\)\="
+syn match perlStatementInclude		"\<\%(use\|no\)\s\+\%(\%(attributes\|attrs\|autodie\%(::\%(exception\%(::system\)\=\|hints\|skip\)\)\=\|autouse\|parent\|base\|big\%(int\|num\|rat\)\|blib\|bytes\|charnames\|constant\|deprecate\|diagnostics\|encoding\%(::warnings\)\=\|experimental\|feature\|fields\|filetest\|if\|integer\|less\|lib\|locale\|mro\|ok\|open\|ops\|overload\|overloading\|re\|sigtrap\|sort\|strict\|subs\|threads\%(::shared\)\=\|utf8\|vars\|version\|vmsish\|warnings\%(::register\)\=\)\>\)\="
 syn match perlStatementProc		"\<\%(alarm\|exec\|fork\|get\%(pgrp\|ppid\|priority\)\|kill\|pipe\|set\%(pgrp\|priority\)\|sleep\|system\|times\|wait\%(pid\)\=\)\>"
 syn match perlStatementSocket		"\<\%(accept\|bind\|connect\|get\%(peername\|sock\%(name\|opt\)\)\|listen\|recv\|send\|setsockopt\|shutdown\|socket\%(pair\)\=\)\>"
 syn match perlStatementIPC		"\<\%(msg\%(ctl\|get\|rcv\|snd\)\|sem\%(ctl\|get\|op\)\|shm\%(ctl\|get\|read\|write\)\)\>"

--- a/t_source/perl/pragmas.t
+++ b/t_source/perl/pragmas.t
@@ -1,0 +1,48 @@
+use attributes ; # Get/set subroutine or variable attributes
+use autodie ; # Replace functions with ones that succeed or die with lexical scope
+use autodie::exception ; # Exceptions from autodying functions.
+use autodie::exception::system ; # Exceptions from autodying system().
+use autodie::hints ; # Provide hints about user subroutines to autodie
+use autodie::skip ; # Skip a package when throwing autodie exceptions
+use autouse ; # Postpone load of modules until a function is used
+use base ; # Establish an ISA relationship with base classes at compile time
+use bigint ; # Transparent BigInteger support for Perl
+use bignum ; # Transparent BigNumber support for Perl
+use bigrat ; # Transparent BigNumber/BigRational support for Perl
+use blib ; # Use MakeMaker's uninstalled version of a package
+use bytes ; # Expose the individual bytes of characters
+use charnames ; # Access to Unicode character names and named character sequences; also define character names
+use constant ; # Declare constants
+use deprecate ; # Perl pragma for deprecating the inclusion of a module in core
+use diagnostics ; # Produce verbose warning diagnostics
+use encoding ; # Allows you to write your script in non-ASCII and non-UTF-8
+use encoding::warnings ; # Warn on implicit encoding conversions
+use experimental ; # Experimental features made easy
+use feature ; # Enable new features
+use fields ; # Compile-time class fields
+use filetest ; # Control the filetest permission operators
+use if ; # use a Perl module if a condition holds
+use integer ; # Use integer arithmetic instead of floating point
+use less ; # Request less of something
+use lib ; # Manipulate @INC at compile time
+use locale ; # Use or avoid POSIX locales for built-in operations
+use mro ; # Method Resolution Order
+use ok ; # Alternative to Test::More::use_ok
+use open ; # Set default PerlIO layers for input and output
+use ops ; # Restrict unsafe operations when compiling
+use overload ; # Package for overloading Perl operations
+use overloading ; # Lexically control overloading
+use parent ; # Establish an ISA relationship with base classes at compile time
+use re ; # Alter regular expression behaviour
+use sigtrap ; # Enable simple signal handling
+use sort ; # Control sort() behaviour
+use strict ; # Restrict unsafe constructs
+use subs ; # Predeclare subroutine names
+use threads ; # Perl interpreter-based threads
+use threads::shared ; # Perl extension for sharing data structures between threads
+use utf8 ; # Enable/disable UTF-8 (or UTF-EBCDIC) in source code
+use vars ; # Predeclare global variable names
+use version ; # Perl extension for Version Objects
+use vmsish ; # Control VMS-specific language features
+use warnings ; # Control optional warnings
+use warnings::register ; # Warnings import function


### PR DESCRIPTION
That pattern is doing a lot of alternation.  I'd think using keywords and nextgroup would improve performance.

`:syntime` tells me it's usually the second worst performing pattern.
