### PR TITLE
Improve POD paragraph highlighting

### DIFF
--- a/syntax/mason.vim
+++ b/syntax/mason.vim
@@ -75,6 +75,7 @@ syn cluster masonTop contains=masonLine,masonExpr,masonPerl,masonComp,masonArgs,
 " syntax files.
 hi def link masonDoc Comment
 hi def link masonPod Comment
+hi def link podOrdinary masonPod
 hi def link masonPerlComment perlComment
 
 let b:current_syntax = "mason"

--- a/syntax/pod.vim
+++ b/syntax/pod.vim
@@ -35,7 +35,7 @@ syn match podEncoding	"[0-9A-Za-z_-]\+" contained contains=@NoSpell
 syn match podCmdText	".*$" contained contains=podFormat,@NoSpell
 
 " Indent amount of =over command
-syn match podOverIndent	"\d\+" contained contains=@NoSpell
+syn match podOverIndent	"\d*\.\=\d\+\>" contained contains=@NoSpell
 
 " Formatter identifier keyword for =for, =begin and =end commands
 syn match podForKeywd	"\S\+" contained contains=@NoSpell
@@ -61,7 +61,7 @@ syn match  podEscape2	"\d\+>"me=e-1 contained contains=@NoSpell
 syn match podCommand    "^=encoding\>"  nextgroup=podEncoding skipwhite contains=@NoSpell
 syn match podCommand    "^=head[1234]"  nextgroup=podCmdText contains=@NoSpell
 syn match podCommand    "^=item"        nextgroup=podCmdText contains=@NoSpell
-syn match podCommand    "^=over"        nextgroup=podOverIndent skipwhite contains=@NoSpell
+syn match podCommand    "^=over\>"      nextgroup=podOverIndent skipwhite contains=@NoSpell
 syn match podCommand    "^=back"        contains=@NoSpell
 syn match podCommand    "^=cut"         contains=@NoSpell
 syn match podCommand    "^=pod"         contains=@NoSpell

--- a/syntax/pod.vim
+++ b/syntax/pod.vim
@@ -28,6 +28,9 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
+" TODO: add supported encodings when we can utilize better performing Vim 8 features
+syn match podEncoding	"[0-9A-Za-z_-]\+" contained contains=@NoSpell
+
 " Text of a =head1, =head2 or =item command
 syn match podCmdText	".*$" contained contains=podFormat,@NoSpell
 
@@ -55,7 +58,7 @@ syn match  podEscape	"\I\i*>"me=e-1 contained contains=@NoSpell
 syn match  podEscape2	"\d\+>"me=e-1 contained contains=@NoSpell
 
 " POD commands
-syn match podCommand    "^=encoding"  nextgroup=podCmdText skipwhite contains=@NoSpell
+syn match podCommand    "^=encoding\>"  nextgroup=podEncoding skipwhite contains=@NoSpell
 syn match podCommand    "^=head[1234]"  nextgroup=podCmdText contains=@NoSpell
 syn match podCommand    "^=item"        nextgroup=podCmdText contains=@NoSpell
 syn match podCommand    "^=over"        nextgroup=podOverIndent skipwhite contains=@NoSpell
@@ -71,6 +74,7 @@ syn match podCommand    "^=end"         nextgroup=podForKeywd skipwhite contains
 
 hi def link podCommand		Statement
 hi def link podCmdText		String
+hi def link podEncoding		Constant
 hi def link podOverIndent	Number
 hi def link podForKeywd		Identifier
 hi def link podFormat		Identifier

--- a/syntax/pod.vim
+++ b/syntax/pod.vim
@@ -28,18 +28,6 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
-" POD commands
-syn match podCommand    "^=encoding"  nextgroup=podCmdText contains=@NoSpell
-syn match podCommand    "^=head[1234]"  nextgroup=podCmdText contains=@NoSpell
-syn match podCommand    "^=item"        nextgroup=podCmdText contains=@NoSpell
-syn match podCommand    "^=over"        nextgroup=podOverIndent skipwhite contains=@NoSpell
-syn match podCommand    "^=back"        contains=@NoSpell
-syn match podCommand    "^=cut"         contains=@NoSpell
-syn match podCommand    "^=pod"         contains=@NoSpell
-syn match podCommand    "^=for"         nextgroup=podForKeywd skipwhite contains=@NoSpell
-syn match podCommand    "^=begin"       nextgroup=podForKeywd skipwhite contains=@NoSpell
-syn match podCommand    "^=end"         nextgroup=podForKeywd skipwhite contains=@NoSpell
-
 " Text of a =head1, =head2 or =item command
 syn match podCmdText	".*$" contained contains=podFormat,@NoSpell
 
@@ -50,7 +38,9 @@ syn match podOverIndent	"\d\+" contained contains=@NoSpell
 syn match podForKeywd	"\S\+" contained contains=@NoSpell
 
 " An indented line, to be displayed verbatim
-syn match podVerbatimLine	"^\s.*$" contains=@NoSpell
+syn region podVerbatim	start="^\s\+\S.*$" end="^\ze\s*$" end="^\ze=cut\>" contains=@NoSpell
+
+syn region podOrdinary	start="^\S.*$" end="^\ze\s*$" end="^\ze=cut\>" contains=podFormat,podSpecial,@NoSpell
 
 " Inline textual items handled specially by POD
 syn match podSpecial	"\(\<\|&\)\I\i*\(::\I\i*\)*([^)]*)" contains=@NoSpell
@@ -64,6 +54,18 @@ syn match  podFormat	"E<\(\d\+\|\I\i*\)>" contains=podEscape,podEscape2,@NoSpell
 syn match  podEscape	"\I\i*>"me=e-1 contained contains=@NoSpell
 syn match  podEscape2	"\d\+>"me=e-1 contained contains=@NoSpell
 
+" POD commands
+syn match podCommand    "^=encoding"  nextgroup=podCmdText skipwhite contains=@NoSpell
+syn match podCommand    "^=head[1234]"  nextgroup=podCmdText contains=@NoSpell
+syn match podCommand    "^=item"        nextgroup=podCmdText contains=@NoSpell
+syn match podCommand    "^=over"        nextgroup=podOverIndent skipwhite contains=@NoSpell
+syn match podCommand    "^=back"        contains=@NoSpell
+syn match podCommand    "^=cut"         contains=@NoSpell
+syn match podCommand    "^=pod"         contains=@NoSpell
+syn match podCommand    "^=for"         nextgroup=podForKeywd skipwhite contains=@NoSpell
+syn match podCommand    "^=begin"       nextgroup=podForKeywd skipwhite contains=@NoSpell
+syn match podCommand    "^=end"         nextgroup=podForKeywd skipwhite contains=@NoSpell
+
 " Define the default highlighting.
 " Only when an item doesn't have highlighting yet
 
@@ -72,7 +74,7 @@ hi def link podCmdText		String
 hi def link podOverIndent	Number
 hi def link podForKeywd		Identifier
 hi def link podFormat		Identifier
-hi def link podVerbatimLine	PreProc
+hi def link podVerbatim		PreProc
 hi def link podSpecial		Identifier
 hi def link podEscape		String
 hi def link podEscape2		Number
@@ -129,7 +131,7 @@ if exists("perl_pod_formatting")
   syn region podIndexAlternativeDelim start="X<<\s"ms=s-2 end="\s>>"me=e oneline contains=podIndexAlternativeDelimOpen
 
   " Restore this (otherwise B<> is shown as bold inside verbatim)
-  syn match podVerbatimLine	"^\s.*$" contains=@NoSpell
+  syn region podVerbatim start="^\s\+\S.*$" end="^\ze\s*$" end="^\ze=cut\>" contains=@NoSpell
 
   " Ensure formatted text can be displayed in headings and items
   syn clear podCmdText

--- a/syntax/pod.vim
+++ b/syntax/pod.vim
@@ -32,7 +32,7 @@ set cpo&vim
 syn match podEncoding	"[0-9A-Za-z_-]\+" contained contains=@NoSpell
 
 " Text of a =head1, =head2 or =item command
-syn match podCmdText	".*$" contained contains=podFormat,@NoSpell
+syn region podCmdText	start="\S.*$" end="^\ze\s*$" end="^\ze=cut\>" contained contains=podFormat,@NoSpell
 
 " Indent amount of =over command
 syn match podOverIndent	"\d*\.\=\d\+\>" contained contains=@NoSpell
@@ -58,16 +58,16 @@ syn match  podEscape	"\I\i*>"me=e-1 contained contains=@NoSpell
 syn match  podEscape2	"\d\+>"me=e-1 contained contains=@NoSpell
 
 " POD commands
-syn match podCommand    "^=encoding\>"  nextgroup=podEncoding skipwhite contains=@NoSpell
-syn match podCommand    "^=head[1234]"  nextgroup=podCmdText contains=@NoSpell
-syn match podCommand    "^=item"        nextgroup=podCmdText contains=@NoSpell
-syn match podCommand    "^=over\>"      nextgroup=podOverIndent skipwhite contains=@NoSpell
-syn match podCommand    "^=back"        contains=@NoSpell
-syn match podCommand    "^=cut"         contains=@NoSpell
-syn match podCommand    "^=pod"         contains=@NoSpell
-syn match podCommand    "^=for"         nextgroup=podForKeywd skipwhite contains=@NoSpell
-syn match podCommand    "^=begin"       nextgroup=podForKeywd skipwhite contains=@NoSpell
-syn match podCommand    "^=end"         nextgroup=podForKeywd skipwhite contains=@NoSpell
+syn match podCommand    "^=encoding\>"   nextgroup=podEncoding skipwhite contains=@NoSpell
+syn match podCommand    "^=head[1234]\>" nextgroup=podCmdText skipwhite skipnl contains=@NoSpell
+syn match podCommand    "^=item\>"       nextgroup=podCmdText skipwhite skipnl contains=@NoSpell
+syn match podCommand    "^=over\>"       nextgroup=podOverIndent skipwhite contains=@NoSpell
+syn match podCommand    "^=back"         contains=@NoSpell
+syn match podCommand    "^=cut"          contains=@NoSpell
+syn match podCommand    "^=pod"          contains=@NoSpell
+syn match podCommand    "^=for"          nextgroup=podForKeywd skipwhite contains=@NoSpell
+syn match podCommand    "^=begin"        nextgroup=podForKeywd skipwhite contains=@NoSpell
+syn match podCommand    "^=end"          nextgroup=podForKeywd skipwhite contains=@NoSpell
 
 " Define the default highlighting.
 " Only when an item doesn't have highlighting yet
@@ -86,7 +86,7 @@ hi def link podEscape2		Number
 if exists("perl_pod_spellcheck_headings")
   " Spell-check headings
   syn clear podCmdText
-  syn match podCmdText    ".*$" contained contains=podFormat
+  syn region podCmdText start="\S.*$" end="^\s*$" end="^\ze=cut\>" contained contains=podFormat
 endif
 
 if exists("perl_pod_formatting")

--- a/t_source/perl/issue14.t
+++ b/t_source/perl/issue14.t
@@ -1,0 +1,12 @@
+vim:ft=pod
+
+=for when we get switching of instances working
+
+    my $sql = <<'HERE';
+        select ....
+HERE
+
+    my $row = sqldo_hashref( $sql ... );
+
+=cut
+

--- a/t_source/perl/issue14.t.json
+++ b/t_source/perl/issue14.t.json
@@ -1,0 +1,1 @@
+[["Label","vim:"],["","ft=pod\n\n"],["Statement","=for"],[""," "],["Identifier","when"],[""," we get switching of instances working\n\n"],["PreProc","    my $sql = <<'HERE';"],["","\n"],["PreProc","        select ...."],["","\n"],["PreProc","HERE"],["","\n\n"],["PreProc","    my $row = sqldo_hashref( $sql ... );"],["","\n\n"],["Statement","=cut"],["","\n\n"]]


### PR DESCRIPTION
Verbatim paragraphs start with a leading whitespace line and continue
until a blank line.

This also prevents indented lines of ordinary paragraphs from being
incorrectly highlighted as verbatim paragraphs.

Fixes #14.

This will require a corpus rebuild.  Highlighting is now correct for:

- corpus/Regexp-Debugger-0.001016/lib/Regexp/Debugger.pm at lines 3154-5
- corpus/Moose-2.1005/lib/Moose/Meta/TypeCoercion/Union.pm at line 68
- corpus/Moose-2.1005/lib/Moose.pm at lines 1002-8
- corpus/Data-Printer-0.35/lib/Data/Printer.pm at lines 1496-1514
