### PR TITLE
Add compiler plugins

### DIFF
--- a/compiler/perl.vim
+++ b/compiler/perl.vim
@@ -1,0 +1,51 @@
+" Vim compiler file
+" Compiler:      Perl syntax checks (perl -Wc)
+" Maintainer:    vim-perl <vim-perl@googlegroups.com>
+" Author:        Christian J. Robinson <heptite@gmail.com>
+" Homepage:      http://github.com/vim-perl/vim-perl
+" Bugs/requests: http://github.com/vim-perl/vim-perl/issues
+" License:       Vim License (see :help license)
+" Last Change:   {{LAST_CHANGE}}
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "perl"
+
+if exists(":CompilerSet") != 2		" older Vim always used :setlocal
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+let s:savecpo = &cpo
+set cpo&vim
+
+if exists('g:perl_compiler_force_warnings') && g:perl_compiler_force_warnings == 0
+	let s:warnopt = 'w'
+else
+	let s:warnopt = 'W'
+endif
+
+if getline(1) =~# '-[^ ]*T'
+	let s:taintopt = 'T'
+else
+	let s:taintopt = ''
+endif
+
+exe 'CompilerSet makeprg=perl\ -' . s:warnopt . s:taintopt . 'c\ %:S'
+
+CompilerSet errorformat=
+	\%-G%.%#had\ compilation\ errors.,
+	\%-G%.%#syntax\ OK,
+	\%m\ at\ %f\ line\ %l.,
+	\%+A%.%#\ at\ %f\ line\ %l\\,%.%#,
+	\%+C%.%#
+
+" Explanation:
+" %-G%.%#had\ compilation\ errors.,  - Ignore the obvious.
+" %-G%.%#syntax\ OK,                 - Don't include the 'a-okay' message.
+" %m\ at\ %f\ line\ %l.,             - Most errors...
+" %+A%.%#\ at\ %f\ line\ %l\\,%.%#,  - As above, including ', near ...'
+" %+C%.%#                            -   ... Which can be multi-line.
+
+let &cpo = s:savecpo
+unlet s:savecpo

--- a/compiler/perl.vim
+++ b/compiler/perl.vim
@@ -19,10 +19,10 @@ endif
 let s:savecpo = &cpo
 set cpo&vim
 
-if exists('g:perl_compiler_force_warnings') && g:perl_compiler_force_warnings == 0
-	let s:warnopt = 'w'
-else
+if get(g:, 'perl_compiler_force_warnings', 1)
 	let s:warnopt = 'W'
+else
+	let s:warnopt = 'w'
 endif
 
 if getline(1) =~# '-[^ ]*T'

--- a/compiler/perlcritic.vim
+++ b/compiler/perlcritic.vim
@@ -1,0 +1,27 @@
+" Vim compiler file
+" Compiler:      perlcritic
+" Maintainer:    vim-perl <vim-perl@googlegroups.com>
+" Author:        Doug Kearns <dougkearns@gmail.com>
+" Homepage:      http://github.com/vim-perl/vim-perl
+" Bugs/requests: http://github.com/vim-perl/vim-perl/issues
+" License:       Vim License (see :help license)
+" Last Change:   {{LAST_CHANGE}}
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "perlcritic"
+
+if exists(":CompilerSet") != 2		" older Vim always used :setlocal
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+CompilerSet makeprg=perlcritic\ --nocolor\ --quiet\ --verbose\ \"\\%f:\\%l:\\%c:\\%s:\\%m\\n\"
+CompilerSet errorformat=%f:%l:%c:%n:%m,
+		       \%-G%.%#
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/compiler/podchecker.vim
+++ b/compiler/podchecker.vim
@@ -1,0 +1,28 @@
+" Vim compiler file
+" Compiler:      podchecker
+" Maintainer:    vim-perl <vim-perl@googlegroups.com>
+" Author:        Doug Kearns <dougkearns@gmail.com>
+" Homepage:      http://github.com/vim-perl/vim-perl
+" Bugs/requests: http://github.com/vim-perl/vim-perl/issues
+" License:       Vim License (see :help license)
+" Last Change:   {{LAST_CHANGE}}
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "podchecker"
+
+if exists(":CompilerSet") != 2          " older Vim always used :setlocal
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+CompilerSet makeprg=podchecker\ -w
+CompilerSet errorformat=\*\*\*\ %tRROR:\ %m\ at\ line\ %l\ in\ file\ %f,
+                       \\*\*\*\ %tARNING:\ %m\ at\ line\ %l\ in\ file\ %f,
+                       \%-G%.%#
+
+let &cpo = s:cpo_save
+unlet s:cpo_save


### PR DESCRIPTION
Add the existing perl compiler plugin (thanks to Christian J. Robinson) and new compiler plugins for podchecker and perlcritic.

PerlCritic is not part of the standard distribution so it should arguably be in `contrib/`.