### PR TITLE
Improve Pod formatting code highlighting

### DIFF
--- a/syntax/pod.vim
+++ b/syntax/pod.vim
@@ -50,8 +50,13 @@ syn match podSpecial	"\(\<\|&\)\I\i*\(::\I\i*\)*([^)]*)" contains=@NoSpell
 syn match podSpecial	"[$@%]\I\i*\(::\I\i*\)*\>" contains=@NoSpell
 
 " Special formatting sequences
-syn region podFormat	start="[IBSCLFX]<[^<]"me=e-1 end=">" oneline contains=podFormat,@NoSpell
-syn region podFormat	start="[IBSCLFX]<<\s" end="\s>>" oneline contains=podFormat,@NoSpell
+
+syn cluster podFormat contains=podFormat,podFormatError
+
+syn match  podFormatError "[ADGHJKM-RT-WY]<"
+
+syn region podFormat	start="[IBSCLFX]<[^<]"me=e-1 end=">" oneline contains=@podFormat,@NoSpell
+syn region podFormat	start="[IBSCLFX]<<\s" end="\s>>" oneline contains=@podFormat,@NoSpell
 syn match  podFormat	"Z<>"
 
 syn region podFormat	start="E<" end=">" oneline contains=podEscape,podEscape2,@NoSpell
@@ -87,6 +92,7 @@ hi def link podOverIndent	Number
 hi def link podForKeywd		Identifier
 hi def link podFormat		Identifier
 hi def link podVerbatim		PreProc
+hi def link podFormatError	Error
 hi def link podSpecial		Identifier
 hi def link podEscape		Constant
 hi def link podEscape2		Number
@@ -101,8 +107,8 @@ if exists("perl_pod_formatting")
   " By default, escapes like C<> are not checked for spelling. Remove B<>
   " and I<> from the list of escapes.
   syn clear podFormat
-  syn region podFormat start="[CLF]<[^<]"me=e-1 end=">" oneline contains=podFormat,@NoSpell
-  syn region podFormat start="[CLF]<<\s" end="\s>>" oneline contains=podFormat,@NoSpell
+  syn region podFormat start="[CLF]<[^<]"me=e-1 end=">" oneline contains=@podFormat,@NoSpell
+  syn region podFormat start="[CLF]<<\s" end="\s>>" oneline contains=@podFormat,@NoSpell
 
   " Don't spell-check inside E<>, but ensure that the E< itself isn't
   " marked as a spelling mistake.
@@ -149,12 +155,12 @@ if exists("perl_pod_formatting")
   syn clear podCmdText
 
   if exists("perl_pod_spellcheck_headings")
-    syn match podCmdText ".*$" contained contains=podFormat,podBold,
+    syn match podCmdText ".*$" contained contains=@podFormat,podBold,
           \podBoldAlternativeDelim,podItalic,podItalicAlternativeDelim,
           \podBoldOpen,podItalicOpen,podBoldAlternativeDelimOpen,
           \podItalicAlternativeDelimOpen,podNoSpaceOpen
   else
-    syn match podCmdText ".*$" contained contains=podFormat,podBold,
+    syn match podCmdText ".*$" contained contains=@podFormat,podBold,
           \podBoldAlternativeDelim,podItalic,podItalicAlternativeDelim,
           \@NoSpell
   endif

--- a/syntax/pod.vim
+++ b/syntax/pod.vim
@@ -55,11 +55,12 @@ syn cluster podFormat contains=podFormat,podFormatError
 
 syn match  podFormatError "[ADGHJKM-RT-WY]<"
 
-syn region podFormat	start="[IBSCLFX]<[^<]"me=e-1 end=">" oneline contains=@podFormat,@NoSpell
-syn region podFormat	start="[IBSCLFX]<<\s\+" end="\s\+>>" oneline contains=@podFormat,@NoSpell
+syn region podFormat	matchgroup=podFormatDelimiter start="[IBSCLFX]<"              end=">"              contains=@podFormat,@NoSpell
+syn region podFormat	matchgroup=podFormatDelimiter start="[IBSCLFX]<<\%(\s\+\|$\)" end="\%(\s\+\|^\)>>" contains=@podFormat,@NoSpell
+
 syn match  podFormat	"Z<>"
 
-syn region podFormat	start="E<" end=">" oneline contains=podEscape,podEscape2,@NoSpell
+syn region podFormat	matchgroup=podFormatDelimiter start="E<" end=">" oneline contains=podEscape,podEscape2,@NoSpell
 
 " HTML entities {{{1
 " Source: Pod/Escapes.pm
@@ -90,8 +91,9 @@ hi def link podCmdText		String
 hi def link podEncoding		Constant
 hi def link podOverIndent	Number
 hi def link podForKeywd		Identifier
-hi def link podFormat		Identifier
 hi def link podVerbatim		PreProc
+hi def link podFormat		Identifier
+hi def link podFormatDelimiter	podFormat
 hi def link podFormatError	Error
 hi def link podSpecial		Identifier
 hi def link podEscape		Constant
@@ -107,8 +109,8 @@ if exists("perl_pod_formatting")
   " By default, escapes like C<> are not checked for spelling. Remove B<>
   " and I<> from the list of escapes.
   syn clear podFormat
-  syn region podFormat start="[CLF]<[^<]"me=e-1 end=">" oneline contains=@podFormat,@NoSpell
-  syn region podFormat start="[CLF]<<\s\+" end="\s\+>>" oneline contains=@podFormat,@NoSpell
+  syn region podFormat start="[CLF]<[^<]"me=e-1 end=">" contains=@podFormat,@NoSpell
+  syn region podFormat start="[CLF]<<\%(\s\+\|$\)" end="\%(\s\+\|^\)>>" contains=@podFormat,@NoSpell
 
   " Don't spell-check inside E<>, but ensure that the E< itself isn't
   " marked as a spelling mistake.
@@ -126,27 +128,27 @@ if exists("perl_pod_formatting")
   syn match podIndexOpen   "X<" contains=@NoSpell
 
   " Same as above but for the << >> syntax.
-  syn match podBoldAlternativeDelimOpen    "B<<\s\+" contains=@NoSpell
-  syn match podItalicAlternativeDelimOpen  "I<<\s\+" contains=@NoSpell
-  syn match podNoSpaceAlternativeDelimOpen "S<<\s\+" contains=@NoSpell
-  syn match podIndexAlternativeDelimOpen   "X<<\s\+" contains=@NoSpell
+  syn match podBoldAlternativeDelimOpen    "B<<\%(\s\+\|$\)" contains=@NoSpell
+  syn match podItalicAlternativeDelimOpen  "I<<\%(\s\+\|$\)" contains=@NoSpell
+  syn match podNoSpaceAlternativeDelimOpen "S<<\%(\s\+\|$\)" contains=@NoSpell
+  syn match podIndexAlternativeDelimOpen   "X<<\%(\s\+\|$\)" contains=@NoSpell
 
   " Add support for spell checking text inside B<>, I<>, S<> and X<>.
-  syn region podBold start="B<[^<]"me=e end=">" oneline contains=podBoldItalic,podBoldOpen
-  syn region podBoldAlternativeDelim start="B<<\s\+" end="\s\+>>" oneline contains=podBoldAlternativeDelimOpen
+  syn region podBold start="B<[^<]"me=e end=">" contains=podBoldItalic,podBoldOpen
+  syn region podBoldAlternativeDelim start="B<<\%(\s\+\|$\)" end="\%(\s\+\|^\)>>" contains=podBoldAlternativeDelimOpen
 
-  syn region podItalic start="I<[^<]"me=e end=">" oneline contains=podItalicBold,podItalicOpen
-  syn region podItalicAlternativeDelim start="I<<\s\+" end="\s\+>>" oneline contains=podItalicAlternativeDelimOpen
+  syn region podItalic start="I<[^<]"me=e end=">" contains=podItalicBold,podItalicOpen
+  syn region podItalicAlternativeDelim start="I<<\%(\s\+\|$\)" end="\%(\s\+\|^\)>>" contains=podItalicAlternativeDelimOpen
 
   " Nested bold/italic and vice-versa
-  syn region podBoldItalic contained start="I<[^<]"me=e end=">" oneline
-  syn region podItalicBold contained start="B<[^<]"me=e end=">" oneline
+  syn region podBoldItalic contained start="I<[^<]"me=e end=">"
+  syn region podItalicBold contained start="B<[^<]"me=e end=">"
 
-  syn region podNoSpace start="S<[^<]"ms=s-2 end=">"me=e oneline contains=podNoSpaceOpen
-  syn region podNoSpaceAlternativeDelim start="S<<\s\+"ms=s-2 end="\s\+>>"me=e oneline contains=podNoSpaceAlternativeDelimOpen
+  syn region podNoSpace start="S<[^<]"ms=s-2 end=">"me=e contains=podNoSpaceOpen
+  syn region podNoSpaceAlternativeDelim start="S<<\%(\s\+\|$\)"ms=s-2 end="\%(\s\+\|^\)>>"me=e contains=podNoSpaceAlternativeDelimOpen
 
-  syn region podIndex start="X<[^<]"ms=s-2 end=">"me=e oneline contains=podIndexOpen
-  syn region podIndexAlternativeDelim start="X<<\s\+"ms=s-2 end="\s\+>>"me=e oneline contains=podIndexAlternativeDelimOpen
+  syn region podIndex start="X<[^<]"ms=s-2 end=">"me=e contains=podIndexOpen
+  syn region podIndexAlternativeDelim start="X<<\%(\s\+\|$\)"ms=s-2 end="\%(\s\+\|^\)>>"me=e contains=podIndexAlternativeDelimOpen
 
   " Restore this (otherwise B<> is shown as bold inside verbatim)
   syn region podVerbatim start="^\s\+\S.*$" end="^\ze\s*$" end="^\ze=cut\>" contains=@NoSpell

--- a/syntax/pod.vim
+++ b/syntax/pod.vim
@@ -53,9 +53,17 @@ syn match podSpecial	"[$@%]\I\i*\(::\I\i*\)*\>" contains=@NoSpell
 syn region podFormat	start="[IBSCLFX]<[^<]"me=e-1 end=">" oneline contains=podFormat,@NoSpell
 syn region podFormat	start="[IBSCLFX]<<\s" end="\s>>" oneline contains=podFormat,@NoSpell
 syn match  podFormat	"Z<>"
-syn match  podFormat	"E<\(\d\+\|\I\i*\)>" contains=podEscape,podEscape2,@NoSpell
-syn match  podEscape	"\I\i*>"me=e-1 contained contains=@NoSpell
-syn match  podEscape2	"\d\+>"me=e-1 contained contains=@NoSpell
+
+syn region podFormat	start="E<" end=">" oneline contains=podEscape,podEscape2,@NoSpell
+
+" HTML entities {{{1
+" Source: Pod/Escapes.pm
+syn keyword podEscape contained lt gt quot amp apos sol verbar lchevron rchevron nbsp iexcl cent pound curren yen brvbar sect uml copy ordf laquo not shy reg macr deg plusmn sup2 sup3 acute micro para middot cedil sup1 ordm raquo frac14 frac12 frac34 iquest Agrave Aacute Acirc Atilde Auml Aring AElig Ccedil Egrave Eacute Ecirc Euml Igrave Iacute Icirc Iuml ETH Ntilde Ograve Oacute Ocirc Otilde Ouml times Oslash Ugrave Uacute Ucirc Uuml Yacute THORN szlig agrave aacute acirc atilde auml aring aelig ccedil egrave eacute ecirc euml igrave iacute icirc iuml eth ntilde ograve oacute ocirc otilde ouml divide oslash ugrave uacute ucirc uuml yacute thorn yuml fnof Alpha Beta Gamma Delta Epsilon Zeta Eta Theta Iota Kappa Lambda Mu Nu Xi Omicron Pi Rho Sigma Tau Upsilon Phi Chi Psi Omega alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigmaf sigma tau upsilon phi chi psi omega thetasym upsih piv bull hellip prime Prime oline frasl weierp image real trade alefsym larr uarr rarr darr harr crarr lArr uArr rArr dArr hArr forall part exist empty nabla isin notin ni prod sum minus lowast radic prop infin ang and or cap cup int there4 sim cong asymp ne equiv le ge sub sup nsub sube supe oplus otimes perp sdot lceil rceil lfloor rfloor lang rang loz spades clubs hearts diams OElig oelig Scaron scaron Yuml circ tilde ensp emsp thinsp zwnj zwj lrm rlm ndash mdash lsquo rsquo sbquo ldquo rdquo bdquo dagger Dagger permil lsaquo rsaquo
+" }}}
+
+syn match  podEscape2	"\d\+"     contained contains=@NoSpell
+syn match  podEscape2	"0\=x\x\+" contained contains=@NoSpell
+syn match  podEscape2	"0\o\+"    contained contains=@NoSpell
 
 " POD commands
 syn match podCommand    "^=encoding\>"   nextgroup=podEncoding skipwhite contains=@NoSpell
@@ -80,7 +88,7 @@ hi def link podForKeywd		Identifier
 hi def link podFormat		Identifier
 hi def link podVerbatim		PreProc
 hi def link podSpecial		Identifier
-hi def link podEscape		String
+hi def link podEscape		Constant
 hi def link podEscape2		Number
 
 if exists("perl_pod_spellcheck_headings")
@@ -98,7 +106,7 @@ if exists("perl_pod_formatting")
 
   " Don't spell-check inside E<>, but ensure that the E< itself isn't
   " marked as a spelling mistake.
-  syn match podFormat   "E<\(\d\+\|\I\i*\)>" contains=podEscape,podEscape2,@NoSpell
+  syn region podFormat	start="E<" end=">" oneline contains=podEscape,podEscape2,@NoSpell
 
   " Z<> is a mock formatting code. Ensure Z<> on its own isn't marked as a
   " spelling mistake.
@@ -179,4 +187,4 @@ let b:current_syntax = "pod"
 let &cpo = s:cpo_save
 unlet s:cpo_save
 
-" vim: ts=8
+" vim: ts=8 fdm=marker:

--- a/syntax/pod.vim
+++ b/syntax/pod.vim
@@ -56,7 +56,7 @@ syn cluster podFormat contains=podFormat,podFormatError
 syn match  podFormatError "[ADGHJKM-RT-WY]<"
 
 syn region podFormat	start="[IBSCLFX]<[^<]"me=e-1 end=">" oneline contains=@podFormat,@NoSpell
-syn region podFormat	start="[IBSCLFX]<<\s" end="\s>>" oneline contains=@podFormat,@NoSpell
+syn region podFormat	start="[IBSCLFX]<<\s\+" end="\s\+>>" oneline contains=@podFormat,@NoSpell
 syn match  podFormat	"Z<>"
 
 syn region podFormat	start="E<" end=">" oneline contains=podEscape,podEscape2,@NoSpell
@@ -108,7 +108,7 @@ if exists("perl_pod_formatting")
   " and I<> from the list of escapes.
   syn clear podFormat
   syn region podFormat start="[CLF]<[^<]"me=e-1 end=">" oneline contains=@podFormat,@NoSpell
-  syn region podFormat start="[CLF]<<\s" end="\s>>" oneline contains=@podFormat,@NoSpell
+  syn region podFormat start="[CLF]<<\s\+" end="\s\+>>" oneline contains=@podFormat,@NoSpell
 
   " Don't spell-check inside E<>, but ensure that the E< itself isn't
   " marked as a spelling mistake.
@@ -126,27 +126,27 @@ if exists("perl_pod_formatting")
   syn match podIndexOpen   "X<" contains=@NoSpell
 
   " Same as above but for the << >> syntax.
-  syn match podBoldAlternativeDelimOpen    "B<< " contains=@NoSpell
-  syn match podItalicAlternativeDelimOpen  "I<< " contains=@NoSpell
-  syn match podNoSpaceAlternativeDelimOpen "S<< " contains=@NoSpell
-  syn match podIndexAlternativeDelimOpen   "X<< " contains=@NoSpell
+  syn match podBoldAlternativeDelimOpen    "B<<\s\+" contains=@NoSpell
+  syn match podItalicAlternativeDelimOpen  "I<<\s\+" contains=@NoSpell
+  syn match podNoSpaceAlternativeDelimOpen "S<<\s\+" contains=@NoSpell
+  syn match podIndexAlternativeDelimOpen   "X<<\s\+" contains=@NoSpell
 
   " Add support for spell checking text inside B<>, I<>, S<> and X<>.
   syn region podBold start="B<[^<]"me=e end=">" oneline contains=podBoldItalic,podBoldOpen
-  syn region podBoldAlternativeDelim start="B<<\s" end="\s>>" oneline contains=podBoldAlternativeDelimOpen
+  syn region podBoldAlternativeDelim start="B<<\s\+" end="\s\+>>" oneline contains=podBoldAlternativeDelimOpen
 
   syn region podItalic start="I<[^<]"me=e end=">" oneline contains=podItalicBold,podItalicOpen
-  syn region podItalicAlternativeDelim start="I<<\s" end="\s>>" oneline contains=podItalicAlternativeDelimOpen
+  syn region podItalicAlternativeDelim start="I<<\s\+" end="\s\+>>" oneline contains=podItalicAlternativeDelimOpen
 
   " Nested bold/italic and vice-versa
   syn region podBoldItalic contained start="I<[^<]"me=e end=">" oneline
   syn region podItalicBold contained start="B<[^<]"me=e end=">" oneline
 
   syn region podNoSpace start="S<[^<]"ms=s-2 end=">"me=e oneline contains=podNoSpaceOpen
-  syn region podNoSpaceAlternativeDelim start="S<<\s"ms=s-2 end="\s>>"me=e oneline contains=podNoSpaceAlternativeDelimOpen
+  syn region podNoSpaceAlternativeDelim start="S<<\s\+"ms=s-2 end="\s\+>>"me=e oneline contains=podNoSpaceAlternativeDelimOpen
 
   syn region podIndex start="X<[^<]"ms=s-2 end=">"me=e oneline contains=podIndexOpen
-  syn region podIndexAlternativeDelim start="X<<\s"ms=s-2 end="\s>>"me=e oneline contains=podIndexAlternativeDelimOpen
+  syn region podIndexAlternativeDelim start="X<<\s\+"ms=s-2 end="\s\+>>"me=e oneline contains=podIndexAlternativeDelimOpen
 
   " Restore this (otherwise B<> is shown as bold inside verbatim)
   syn region podVerbatim start="^\s\+\S.*$" end="^\ze\s*$" end="^\ze=cut\>" contains=@NoSpell


### PR DESCRIPTION
- Improve Pod E<...> format code highlighting
- Highlight unrecognised Pod formatting codes as errors
- Include all whitespace in multibracket formatting code delimiters
- Allow Pod formatting code regions to cross line boundaries

This will require a corpus rebuild.  The following files are now correctly highlighted:

- corpus/Data-Printer-0.35/lib/Data/Printer/Filter.pm
- corpus/Moose-2.1005/lib/Class/MOP.pm
- corpus/Moose-2.1005/lib/Moose.pm
- corpus/Data-Printer-0.35/lib/Data/Printer.pm
- corpus/Moose-2.1005/lib/Class/MOP/Class.pm
- corpus/Moose-2.1005/lib/Moose/Meta/Class.pm
- corpus/Moose-2.1005/lib/Moose/Meta/Attribute.pm
- corpus/Moose-2.1005/lib/Moose/Util/TypeConstraints.pm
- corpus/Regexp-Debugger-0.001016/lib/Regexp/Debugger.pm
