### PR TITLE
Fix issue 314 pod ordinary spellchecking

### DIFF
--- a/syntax/perl.vim
+++ b/syntax/perl.vim
@@ -443,10 +443,17 @@ syn match  perlFormatField	"@$" contained
 " known workaround for that case.
 if get(g:, 'perl_fold', 0)
   syntax region perlDATA matchgroup=perlDATAStart start="^__DATA__$" end="VIM_PERL_EOF\%$" contains=@perlDATA fold
-  syntax region perlDATA matchgroup=perlDATAStart start="^__END__$"  end="VIM_PERL_EOF\%$" contains=perlPOD,@perlDATA fold
+  syntax region perlEND  matchgroup=perlENDStart  start="^__END__$"  end="VIM_PERL_EOF\%$" contains=@perlDATA fold
 else
   syntax region perlDATA matchgroup=perlDATAStart start="^__DATA__$" end="\%$" contains=@perlDATA
-  syntax region perlDATA matchgroup=perlDATAStart start="^__END__$"  end="\%$" contains=perlPOD,@perlDATA
+  syntax region perlEND  matchgroup=perlENDStart  start="^__END__$"  end="\%$" contains=@perlDATA
+endif
+
+" TODO: generalise this to allow other filetypes
+if get(g:, 'perl_highlight_data', 0)
+  syn cluster perlDATA add=perlPOD
+else
+  syn cluster perlDATA remove=perlPOD
 endif
 
 "
@@ -597,6 +604,8 @@ hi def link perlSpecialDollar		perlSpecial
 hi def link perlSpecialString		perlSpecial
 hi def link perlSpecialStringU		perlSpecial
 hi def link perlSpecialMatch		perlSpecial
+hi def link perlEND			perlComment
+hi def link perlENDStart		perlEND
 hi def link perlDATA			perlComment
 hi def link perlDATAStart		perlDATA
 

--- a/syntax/pod.vim
+++ b/syntax/pod.vim
@@ -43,7 +43,7 @@ syn match podForKeywd	"\S\+" contained contains=@NoSpell
 " An indented line, to be displayed verbatim
 syn region podVerbatim	start="^\s\+\S.*$" end="^\ze\s*$" end="^\ze=cut\>" contains=@NoSpell
 
-syn region podOrdinary	start="^\S.*$" end="^\ze\s*$" end="^\ze=cut\>" contains=podFormat,podSpecial,@NoSpell
+syn region podOrdinary	start="^\S.*$" end="^\ze\s*$" end="^\ze=cut\>" contains=podFormat,podSpecial,@Spell
 
 " Inline textual items handled specially by POD
 syn match podSpecial	"\(\<\|&\)\I\i*\(::\I\i*\)*([^)]*)" contains=@NoSpell


### PR DESCRIPTION
- Fix spellchecking of POD ordinary paragraphs
- Optionally highlight POD in `__END__` and `__DATA__` sections

Fixes #314.