### PR TITLE
contrib/heredoc-sql: support <<~ indented heredoc

### DIFF
--- a/contrib/heredoc-sql-mason.vim
+++ b/contrib/heredoc-sql-mason.vim
@@ -14,10 +14,18 @@ if get(g:, 'perl_fold', 0)
   syntax region perlHereDocSQL matchgroup=perlStringStartEnd start=+<<\s*'\z(\%(END_\)\=SQL\)'+ end='^\z1$' contained contains=@SQL               fold extend
   syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\s*"\z(\%(END_\)\=SQL\)"' end='^\z1$' contained contains=@perlInterpDQ,@SQL fold extend
   syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\s*\z(\%(END_\)\=SQL\)'   end='^\z1$' contained contains=@perlInterpDQ,@SQL fold extend
+
+  syntax region perlHereDocSQL matchgroup=perlStringStartEnd start=+<<\~\s*'\z(\%(END_\)\=SQL\)'+ end='^\s*\z1$' contained contains=@SQL               fold extend
+  syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\~\s*"\z(\%(END_\)\=SQL\)"' end='^\s*\z1$' contained contains=@perlInterpDQ,@SQL fold extend
+  syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\~\s*\z(\%(END_\)\=SQL\)'   end='^\s*\z1$' contained contains=@perlInterpDQ,@SQL fold extend
 else
   syntax region perlHereDocSQL matchgroup=perlStringStartEnd start=+<<\s*'\z(\%(END_\)\=SQL\)'+ end='^\z1$' contained contains=@SQL
   syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\s*"\z(\%(END_\)\=SQL\)"' end='^\z1$' contained contains=@perlInterpDQ,@SQL
   syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\s*\z(\%(END_\)\=SQL\)'   end='^\z1$' contained contains=@perlInterpDQ,@SQL
+
+  syntax region perlHereDocSQL matchgroup=perlStringStartEnd start=+<<\~\s*'\z(\%(END_\)\=SQL\)'+ end='^\s*\z1$' contained contains=@SQL
+  syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\~\s*"\z(\%(END_\)\=SQL\)"' end='^\s*\z1$' contained contains=@perlInterpDQ,@SQL
+  syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\~\s*\z(\%(END_\)\=SQL\)'   end='^\s*\z1$' contained contains=@perlInterpDQ,@SQL
 endif
 
 syn cluster perlTop add=perlHereDocSQL

--- a/contrib/heredoc-sql.vim
+++ b/contrib/heredoc-sql.vim
@@ -14,8 +14,16 @@ if get(g:, 'perl_fold', 0)
   syntax region perlHereDocSQL matchgroup=perlStringStartEnd start=+<<\s*'\z(\%(END_\)\=SQL\)'+ end='^\z1$' contains=@SQL               fold extend
   syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\s*"\z(\%(END_\)\=SQL\)"' end='^\z1$' contains=@perlInterpDQ,@SQL fold extend
   syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\s*\z(\%(END_\)\=SQL\)'   end='^\z1$' contains=@perlInterpDQ,@SQL fold extend
+
+  syntax region perlHereDocSQL matchgroup=perlStringStartEnd start=+<<\~\s*'\z(\%(END_\)\=SQL\)'+ end='^\s*\z1$' contains=@SQL               fold extend
+  syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\~\s*"\z(\%(END_\)\=SQL\)"' end='^\s*\z1$' contains=@perlInterpDQ,@SQL fold extend
+  syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\~\s*\z(\%(END_\)\=SQL\)'   end='^\s*\z1$' contains=@perlInterpDQ,@SQL fold extend
 else
   syntax region perlHereDocSQL matchgroup=perlStringStartEnd start=+<<\s*'\z(\%(END_\)\=SQL\)'+ end='^\z1$' contains=@SQL
   syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\s*"\z(\%(END_\)\=SQL\)"' end='^\z1$' contains=@perlInterpDQ,@SQL
   syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\s*\z(\%(END_\)\=SQL\)'   end='^\z1$' contains=@perlInterpDQ,@SQL
+
+  syntax region perlHereDocSQL matchgroup=perlStringStartEnd start=+<<\~\s*'\z(\%(END_\)\=SQL\)'+ end='^\s*\z1$' contains=@SQL
+  syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\~\s*"\z(\%(END_\)\=SQL\)"' end='^\s*\z1$' contains=@perlInterpDQ,@SQL
+  syntax region perlHereDocSQL matchgroup=perlStringStartEnd start='<<\~\s*\z(\%(END_\)\=SQL\)'   end='^\s*\z1$' contains=@perlInterpDQ,@SQL
 endif


### PR DESCRIPTION
This commit adds support for `<<~SQL` to the contrib/heredoc-sql files.  Indented heredocs have been supported for a while by vim-perl, this just wasn't able to match for the embedded SQL syntax.