### PR TITLE
Fix "All Files" browsefilter patterns to include files with no extension

### DIFF
--- a/ftplugin/perl.vim
+++ b/ftplugin/perl.vim
@@ -93,7 +93,7 @@ if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
     let b:browsefilter = "Perl Source Files (*.pl)\t*.pl\n" .
 		       \ "Perl Modules (*.pm)\t*.pm\n" .
 		       \ "Perl Documentation Files (*.pod)\t*.pod\n" .
-		       \ "All Files (*.*)\t*.*\n"
+		       \ "All Files\t*\n"
     let b:undo_ftplugin .= " | unlet! b:browsefilter"
 endif
 

--- a/ftplugin/pod.vim
+++ b/ftplugin/pod.vim
@@ -34,7 +34,7 @@ if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:browsefilter = "POD Source Files (*.pod)\t*.pod\n" .
         \              "Perl Source Files (*.pl)\t*.pl\n" .
         \              "Perl Modules (*.pm)\t*.pm\n" .
-        \              "All Files (*.*)\t*.*\n"
+        \              "All Files\t*\n"
   let b:undo_ftplugin .= " | unlet! b:browsefilter"
 endif
 


### PR DESCRIPTION
See https://github.com/vim/vim/issues/12685
