### PR TITLE
Fix @INC discovery using the rc shell

### DIFF
--- a/Changes
+++ b/Changes
@@ -82,6 +82,9 @@ Stop setting "iskeyword" globally. (Hinrik)
 
 Fix folding for subroutines with prototypes. (zdm)
 
+Change handling of "&shellxquote": use single-quotes by default. This
+fixes "@INC" discovery for rc-shell users. (odc)
+
 [TESTING]
 Added a test harness in t/ (try "make test"). Moved example code
 to t_source/ (Hinrik)

--- a/ftplugin/perl.vim
+++ b/ftplugin/perl.vim
@@ -57,7 +57,7 @@ if !exists("perlpath")
     " safety check: don't execute perl from current directory
     if executable("perl") && fnamemodify(exepath("perl"), ":p:h") != getcwd()
       try
-	if &shellxquote != '"'
+	if &shellxquote == '"'
 	    let perlpath = system('perl -e "print join(q/,/,@INC)"')
 	else
 	    let perlpath = system("perl -e 'print join(q/,/,@INC)'")


### PR DESCRIPTION
If &shellxquote is set to '"' (required for cmd.exe) then use double-quotes. Else, default to single-quotes which work with pretty much any other shell out there, including rc.

Fixes #45 